### PR TITLE
Feature #2 트윗추가 및 프로필 사진 변경시 이미지 등록 로직 변경

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npx lint-staged
+npx tsc

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "build": "next build && prisma generate",
     "start": "next start",
     "lint": "next lint",
-    "prepare": "husky install",
-    "db-sync": "npx prisma migrate dev"
+    "prepare": "husky install"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,14 +22,13 @@ model User {
   likes     Like[]
   comments  Comment[]
   profile   Profile?
-  
 }
 
 model Profile {
   id     String  @id @default(uuid())
   bio    String
   avatar String
-  user   User    @relation(fields: [userId], references: [id])
+  user   User    @relation(fields: [userId], references: [id], onDelete:Cascade)
   userId String  @unique
   @@index([userId])
 }

--- a/src/hooks/useSelectImage.ts
+++ b/src/hooks/useSelectImage.ts
@@ -1,20 +1,32 @@
+import getImageId from '@/libs/client/getImageId';
 import { useState } from 'react';
 
 export default function useSelectImage() {
+  const [isImageLoading, setIsImageLoading] = useState(false);
+  const [imageId, setImageId] = useState('');
   const [previewImage, setPreviewImage] = useState('');
-  const [imageFile, setImageFile] = useState<File>();
 
-  const selectedImage = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const selectedImage = async (event: React.ChangeEvent<HTMLInputElement>) => {
     if (event.target.files && event.target.files.length > 0) {
+      setIsImageLoading(true);
+
       const file = event.target.files[0];
-      setImageFile(file);
-      setPreviewImage(URL.createObjectURL(file));
+      const previewImageUrl = URL.createObjectURL(file);
+      setPreviewImage(previewImageUrl);
+
+      const id = await getImageId(file, file.name);
+      setImageId(id);
+
+      setIsImageLoading(false);
+      event.target.value = '';
     }
   };
+
   const cancelImage = () => {
+    URL.revokeObjectURL(previewImage);
+    setImageId('');
     setPreviewImage('');
-    setImageFile(undefined);
   };
 
-  return { cancelImage, imageFile, previewImage, selectedImage };
+  return { cancelImage, imageId, isImageLoading, previewImage, selectedImage };
 }

--- a/src/libs/client/getImageId.ts
+++ b/src/libs/client/getImageId.ts
@@ -1,9 +1,9 @@
-export default async function getImageId(imageFile: File, input: string) {
+export default async function getImageId(imageFile: File, fileName: string) {
   const {
     data: { uploadURL },
   } = await (await fetch('/api/files')).json();
   const form = new FormData();
-  form.append('file', imageFile, input.slice(5));
+  form.append('file', imageFile, fileName);
   const {
     result: { id },
   } = await (await fetch(uploadURL, { body: form, method: 'POST' })).json();

--- a/src/libs/client/validators.ts
+++ b/src/libs/client/validators.ts
@@ -61,13 +61,13 @@ export function bioValidator(bio: React.InputHTMLAttributes<HTMLInputElement | H
   return { isValid: true, message: '' };
 }
 
-export function tweetValidator(tweet: React.InputHTMLAttributes<HTMLInputElement | HTMLTextAreaElement>['value']) {
+export function basicTextValidator(tweet: React.InputHTMLAttributes<HTMLInputElement | HTMLTextAreaElement>['value']) {
   if (typeof tweet !== 'string') {
-    return { isValid: false, message: '유효한 트윗 입력 부탁드립니다.' };
+    return { isValid: false, message: '유효한 입력 부탁드립니다.' };
   }
 
   if (tweet.trim().length < 1) {
-    return { isValid: false, message: '트윗은 공백으로만 작성할 수 없습니다.' };
+    return { isValid: false, message: '공백으로만 작성할 수 없습니다.' };
   }
   return { isValid: true, message: '' };
 }

--- a/src/pages/log-in/index.tsx
+++ b/src/pages/log-in/index.tsx
@@ -41,7 +41,7 @@ export default function LogIn() {
         <form className="flex flex-col w-full gap-1 px-10" onSubmit={handleLogIn}>
           <Input
             disabled={isLoading}
-            errorMassage={!errors.email.isValid && errors.email.message}
+            errorMassage={form.email && !errors.email.isValid && errors.email.message}
             name="email"
             onChange={onChange}
             placeholder="Your email"
@@ -51,7 +51,7 @@ export default function LogIn() {
           />
           <Input
             disabled={isLoading}
-            errorMassage={!errors.password.isValid && errors.password.message}
+            errorMassage={form.password && !errors.password.isValid && errors.password.message}
             name="password"
             onChange={onChange}
             placeholder="Your password"

--- a/src/pages/profile/edit.tsx
+++ b/src/pages/profile/edit.tsx
@@ -18,6 +18,8 @@ export default function ProfileEdit() {
   const router = useRouter();
   const { data: profile } = useSWR<ResponseType<ProfileResponse>>('/api/users/profile');
   const [isLoading, setIsLoading] = useState(false);
+  const [isEditedProfileSubmissionInProgress, setIsEditedProfileSubmissionInProgress] = useState(false);
+
   const { errorMessage, errors, form, isError, onChange } = useForm<EditProfileInput>(
     {
       bio: profile?.data?.profile?.bio || '',
@@ -28,35 +30,47 @@ export default function ProfileEdit() {
       username: usernameValidator,
     }
   );
-  const [editProfile, { data: editProfileData, error: editProfileError }] =
+  const [editProfile, { data: editProfileData, error: editProfileError, isLoading: isEditProfileApiLoading }] =
     useMutation<ResponseType<ProfileResponse>>();
   const { imageId, isImageLoading, previewImage, selectedImage } = useSelectImage();
-  const handleEditProfile = async () => {
-    if (isError) return alert(errorMessage.at(0));
-    setIsLoading(true);
-    if (imageId) {
-      await editProfile('/api/users/profile', METHOD.PUT, {
-        avatarId: imageId,
-        bio: form.bio,
-        name: form.username,
-      });
-    } else {
-      await editProfile('/api/users/profile', METHOD.PUT, {
-        avatarId: profile?.data?.profile?.avatar,
-        bio: form.bio,
-        name: form.username,
-      });
-    }
-  };
+
   useEffect(() => {
     if (editProfileData?.isSuccess) {
-      setIsLoading(false);
+      setIsEditedProfileSubmissionInProgress(false);
       router.push(ROUTE_PATH.PROFILE);
     } else if (editProfileError) {
       alert(editProfileData?.message);
       console.error(editProfileData);
     }
   }, [editProfileData, router, editProfileError]);
+
+  const handleEditProfile = async () => {
+    if (isError) return alert(errorMessage.at(0));
+    setIsEditedProfileSubmissionInProgress(true);
+    if (!previewImage) {
+      await editProfile('/api/users/profile', METHOD.PUT, {
+        avatarId: profile?.data?.profile?.avatar,
+        bio: form.bio,
+        name: form.username,
+      });
+      setIsEditedProfileSubmissionInProgress(false);
+    }
+  };
+  if (imageId) {
+  }
+
+  useEffect(() => {
+    if (!isImageLoading && imageId && isEditedProfileSubmissionInProgress) {
+      editProfile('/api/users/profile', METHOD.PUT, {
+        avatarId: imageId,
+        bio: form.bio,
+        name: form.username,
+      });
+      setIsEditedProfileSubmissionInProgress(false);
+    }
+  }, [imageId, form.bio, form.username, isImageLoading, isEditedProfileSubmissionInProgress, editProfile]);
+
+  const isCreatingTweet = isEditProfileApiLoading || isEditedProfileSubmissionInProgress;
 
   return (
     <Layout hasBackButton isLoggedIn title="MY PAGE">
@@ -88,7 +102,7 @@ export default function ProfileEdit() {
             <input
               accept="image/*"
               className="hidden"
-              disabled={isLoading}
+              disabled={isCreatingTweet}
               id="image"
               name="image"
               onChange={selectedImage}
@@ -96,7 +110,7 @@ export default function ProfileEdit() {
             />
           </label>
           <Input
-            disabled={isLoading}
+            disabled={isCreatingTweet}
             errorMassage={form.username && !errors.username.isValid && errors.username.message}
             isEditMode
             name="username"
@@ -109,7 +123,7 @@ export default function ProfileEdit() {
           <small className="text-stone-500">{profile?.data?.email}</small>
         </div>
         <Textarea
-          disabled={isLoading}
+          disabled={isCreatingTweet}
           errorMassage={form.bio && !errors.bio.isValid && errors.bio.message}
           name="bio"
           onChange={onChange}
@@ -119,11 +133,11 @@ export default function ProfileEdit() {
         />
         <button
           className="w-3/5 text-center button disabled:border-none disabled:bg-stone-400"
-          disabled={isLoading || isImageLoading}
+          disabled={isCreatingTweet}
           onClick={handleEditProfile}
         >
-          <span className={parameterToString('font-semibold ', isLoading || isImageLoading ? 'text-stone-100' : '')}>
-            {isLoading ? '수정중...' : isImageLoading ? '프로플이미지 등록중..' : '수정완료'}
+          <span className={parameterToString('font-semibold ', isCreatingTweet ? 'text-stone-100' : '')}>
+            {isCreatingTweet ? '수정중...' : '수정완료'}
           </span>
         </button>
       </main>

--- a/src/pages/profile/edit.tsx
+++ b/src/pages/profile/edit.tsx
@@ -4,7 +4,7 @@ import Textarea from '@/components/common/Textarea';
 import { METHOD, ROUTE_PATH } from '@/constants';
 import { useForm, useSelectImage } from '@/hooks';
 import { makeImagePath, useMutation } from '@/libs/client';
-import getImageId from '@/libs/client/getImageId';
+import { parameterToString } from '@/libs/client/utils';
 import { bioValidator, usernameValidator } from '@/libs/client/validators';
 import { ProfileResponse, ResponseType } from '@/types';
 import Image from 'next/image';
@@ -30,14 +30,13 @@ export default function ProfileEdit() {
   );
   const [editProfile, { data: editProfileData, error: editProfileError }] =
     useMutation<ResponseType<ProfileResponse>>();
-  const { imageFile, previewImage, selectedImage } = useSelectImage();
+  const { imageId, isImageLoading, previewImage, selectedImage } = useSelectImage();
   const handleEditProfile = async () => {
     if (isError) return alert(errorMessage.at(0));
     setIsLoading(true);
-    if (imageFile) {
-      const id = await getImageId(imageFile, form.username);
+    if (imageId) {
       await editProfile('/api/users/profile', METHOD.PUT, {
-        avatarId: id,
+        avatarId: imageId,
         bio: form.bio,
         name: form.username,
       });
@@ -118,8 +117,14 @@ export default function ProfileEdit() {
           textareaStyle="h-40 p-2 mx-5 mt-10 text-lg border-2 resize-none rounded-xl border-stone-200"
           value={form.bio}
         />
-        <button className="w-3/5 text-center button" disabled={isLoading} onClick={handleEditProfile}>
-          <span className="font-semibold "> {isLoading ? '수정중...' : '수정완료'}</span>
+        <button
+          className="w-3/5 text-center button disabled:border-none disabled:bg-stone-400"
+          disabled={isLoading || isImageLoading}
+          onClick={handleEditProfile}
+        >
+          <span className={parameterToString('font-semibold ', isLoading || isImageLoading ? 'text-stone-100' : '')}>
+            {isLoading ? '수정중...' : isImageLoading ? '프로플이미지 등록중..' : '수정완료'}
+          </span>
         </button>
       </main>
     </Layout>

--- a/src/pages/tweet/[id].tsx
+++ b/src/pages/tweet/[id].tsx
@@ -4,13 +4,12 @@ import { useForm } from '@/hooks';
 import useDelete from '@/hooks/useDelete';
 import { useMutation } from '@/libs/client';
 import maskEmail from '@/libs/client/maskEmail';
-import { tweetValidator } from '@/libs/client/validators';
+import { basicTextValidator } from '@/libs/client/validators';
 import { db, withSsrSession } from '@/libs/server';
-import { CommentResponse, ResponseType, TweetResponse, UploadTweetInput } from '@/types';
+import { CommentResponse, ResponseType, TweetResponse, UploadBasicInputText } from '@/types';
 import { Profile } from '@prisma/client';
 import { GetServerSidePropsContext } from 'next';
 import { useRouter } from 'next/router';
-import { useEffect } from 'react';
 import { AiOutlineDelete } from 'react-icons/ai';
 import useSWR from 'swr';
 
@@ -61,9 +60,9 @@ export default function DetailTweet({ loggedInUser }: LoggedInUsr) {
       );
     }
   };
-  const { errorMessage, form, isError, onChange, reset } = useForm<UploadTweetInput>(
+  const { errorMessage, form, isError, onChange, reset } = useForm<UploadBasicInputText>(
     { text: '' },
-    { text: tweetValidator }
+    { text: basicTextValidator }
   );
   const handleUploadComment = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/src/pages/tweet/upload.tsx
+++ b/src/pages/tweet/upload.tsx
@@ -3,7 +3,7 @@ import Textarea from '@/components/common/Textarea';
 import { METHOD, ROUTE_PATH } from '@/constants';
 import { useForm, useSelectImage } from '@/hooks';
 import { useMutation } from '@/libs/client';
-import getImageId from '@/libs/client/getImageId';
+import { parameterToString } from '@/libs/client/utils';
 import { tweetValidator } from '@/libs/client/validators';
 import { ResponseType, TweetResponse, UploadTweetInput } from '@/types';
 import Image from 'next/image';
@@ -19,7 +19,7 @@ export default function Upload() {
     { text: '' },
     { text: tweetValidator }
   );
-  const { cancelImage, imageFile, previewImage, selectedImage } = useSelectImage();
+  const { cancelImage, imageId, isImageLoading, previewImage, selectedImage } = useSelectImage();
 
   useEffect(() => {
     if (createdTweet?.isSuccess) {
@@ -35,9 +35,8 @@ export default function Upload() {
     event.preventDefault();
     if (isError) return alert(errorMessage.at(0));
     setIsLoading(true);
-    if (imageFile) {
-      const id = await getImageId(imageFile, form.text);
-      await createTweet('/api/tweets', METHOD.POST, { imageId: id, text: form.text });
+    if (imageId) {
+      await createTweet('/api/tweets', METHOD.POST, { imageId, text: form.text });
     } else {
       await createTweet('/api/tweets', METHOD.POST, { text: form.text });
     }
@@ -72,8 +71,13 @@ export default function Upload() {
           textareaStyle="w-11/12 h-40 p-2 mx-5 mt-10 text-lg border-2 resize-none rounded-xl border-stone-200"
           value={form.text}
         />
-        <button className="w-3/5 text-center button" disabled={isLoading}>
-          <span className="font-semibold "> {isLoading ? '등록중...' : '추가하기'}</span>
+        <button
+          className="w-3/5 text-center button disabled:border-none disabled:bg-stone-400"
+          disabled={isLoading || isImageLoading}
+        >
+          <span className={parameterToString('font-semibold ', isLoading || isImageLoading ? 'text-stone-100' : '')}>
+            {isLoading ? '트윗 등록중...' : isImageLoading ? '이미지 등록중..' : '추가하기'}
+          </span>
         </button>
       </form>
     </Layout>

--- a/src/pages/tweet/upload.tsx
+++ b/src/pages/tweet/upload.tsx
@@ -16,8 +16,8 @@ export default function Upload() {
   const router = useRouter();
   const [createTweet, { data: createdTweet, error: createdTweetError }] = useMutation<ResponseType<TweetResponse>>();
   const { errorMessage, errors, form, isError, onChange, reset } = useForm<UploadTweetInput>(
-    { text: '' },
-    { text: tweetValidator }
+    { tweet: '' },
+    { tweet: tweetValidator }
   );
   const { cancelImage, imageId, isImageLoading, previewImage, selectedImage } = useSelectImage();
 
@@ -36,9 +36,9 @@ export default function Upload() {
     if (isError) return alert(errorMessage.at(0));
     setIsLoading(true);
     if (imageId) {
-      await createTweet('/api/tweets', METHOD.POST, { imageId, text: form.text });
+      await createTweet('/api/tweets', METHOD.POST, { imageId, text: form.tweet });
     } else {
-      await createTweet('/api/tweets', METHOD.POST, { text: form.text });
+      await createTweet('/api/tweets', METHOD.POST, { text: form.tweet });
     }
     reset();
   };
@@ -64,12 +64,12 @@ export default function Upload() {
         </button>
         <Textarea
           disabled={isLoading}
-          errorMassage={form.text && !errors.text.isValid && errors.text.message}
-          name="text"
+          errorMassage={form.tweet && !errors.tweet.isValid && errors.tweet.message}
+          name="tweet"
           onChange={onChange}
           placeholder="텍스트를 입력해주세요."
           textareaStyle="w-11/12 h-40 p-2 mx-5 mt-10 text-lg border-2 resize-none rounded-xl border-stone-200"
-          value={form.text}
+          value={form.tweet}
         />
         <button
           className="w-3/5 text-center button disabled:border-none disabled:bg-stone-400"

--- a/src/pages/tweet/upload.tsx
+++ b/src/pages/tweet/upload.tsx
@@ -4,8 +4,8 @@ import { METHOD, ROUTE_PATH } from '@/constants';
 import { useForm, useSelectImage } from '@/hooks';
 import { useMutation } from '@/libs/client';
 import { parameterToString } from '@/libs/client/utils';
-import { tweetValidator } from '@/libs/client/validators';
-import { ResponseType, TweetResponse, UploadTweetInput } from '@/types';
+import { basicTextValidator } from '@/libs/client/validators';
+import { ResponseType, TweetResponse, UploadBasicInputText } from '@/types';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
@@ -16,9 +16,9 @@ export default function Upload() {
   const router = useRouter();
   const [createTweet, { data: createdTweet, error: createdTweetError, isLoading: isCreateTweetApiLoading }] =
     useMutation<ResponseType<TweetResponse>>();
-  const { errorMessage, errors, form, isError, onChange } = useForm<UploadTweetInput>(
-    { tweet: '' },
-    { tweet: tweetValidator }
+  const { errorMessage, errors, form, isError, onChange } = useForm<UploadBasicInputText>(
+    { text: '' },
+    { text: basicTextValidator }
   );
   const { cancelImage, imageId, isImageLoading, previewImage, selectedImage } = useSelectImage();
 
@@ -37,17 +37,17 @@ export default function Upload() {
     setIsTweetSubmissionInProgress(true);
 
     if (!previewImage) {
-      await createTweet('/api/tweets', METHOD.POST, { text: form.tweet });
+      await createTweet('/api/tweets', METHOD.POST, { text: form.text });
       setIsTweetSubmissionInProgress(false);
     }
   };
 
   useEffect(() => {
     if (!isImageLoading && imageId && isTweetSubmissionInProgress) {
-      createTweet('/api/tweets', METHOD.POST, { imageId, text: form.tweet });
+      createTweet('/api/tweets', METHOD.POST, { imageId, text: form.text });
       setIsTweetSubmissionInProgress(false);
     }
-  }, [imageId, form.tweet, createTweet, isImageLoading, isTweetSubmissionInProgress]);
+  }, [imageId, form.text, createTweet, isImageLoading, isTweetSubmissionInProgress]);
 
   const isCreatingTweet = isTweetSubmissionInProgress || isCreateTweetApiLoading;
 
@@ -72,12 +72,12 @@ export default function Upload() {
         </button>
         <Textarea
           disabled={isCreatingTweet}
-          errorMassage={form.tweet && !errors.tweet.isValid && errors.tweet.message}
+          errorMassage={form.text && !errors.tweet.isValid && errors.tweet.message}
           name="tweet"
           onChange={onChange}
           placeholder="텍스트를 입력해주세요."
           textareaStyle="w-11/12 h-40 p-2 mx-5 mt-10 text-lg border-2 resize-none rounded-xl border-stone-200"
-          value={form.tweet}
+          value={form.text}
         />
         <button
           className="w-3/5 text-center button disabled:border-none disabled:bg-stone-400"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -50,4 +50,4 @@ export interface CommentResponse extends Comment {
   };
 }
 
-export type UploadTweetInput = { tweet: string };
+export type UploadBasicInputText = { text: string };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -50,4 +50,4 @@ export interface CommentResponse extends Comment {
   };
 }
 
-export type UploadTweetInput = { text: string };
+export type UploadTweetInput = { tweet: string };


### PR DESCRIPTION
# Feature
- 트윗추가 및 프로필 사진 변경시 이미지 등록 로직 변경 

Closes #2 
Closes #1 

# Description

## 이미지 등록 로직 변경

### 변경 이유
- 사용자가 글과 이미지를 작성 및 수정한 다음 작성완료를 클릭하게 되면 아래의 단계를 진행한다.
    1. cloudflare image 에 이미지를 등록하고 imageId를 얻는다
    2. 사용자가 작성한 글과 imageId를 데이터베이스에 등록한다.
 - 위의 두 단계가 순차적으로 진행완료 될 떄까지 사용자는 대기를 해야한다.(사용자 입력 비허용 및 등록 중인 것을 표시)
 - 현재 API 요청응답이 무척 느리기 떄문에(이유를 알 수 없음) **최대한 사용자 대기시간을 줄여야 한다.**  

### 사용자가 이미지를 선택하고 프리뷰 이미지 로 등록될 때, 미리 ImageId를 받아오는 형식으로 변경

1. 사용자가 게시글 등록 및 프로필 변경 페이지에 진입한다.
2. 사용자가 이미지를 선택한다
    - 선택한 이미지는 프리뷰 이미지로 사용자에게 보여준다.
    - 선택한 이미지를 바로 cloudflare에 등록하여 imageId를 받아온다.
3. 폼 작성을완료 하고 등록하기/변겨경하기 버튼을 클릭한다.
4. 이미 이미지를 등록하여 받은 ImageId값과 폼 내용과 함께 데이터베이스에 등록 요청한다. **(로딩상태 표시)**
5. 등록이 완료될 떄까지 사용자에게 로딩 상태를 표시해준다.

|변경 전| 변경 후 |
|-|-|
|![image](https://github.com/user-attachments/assets/7dc4e0b8-5a05-4e8c-b1ac-1ad3b0de79c0)|![image](https://github.com/user-attachments/assets/11bdf9c8-7322-4411-ae8b-0746e3b07557)|

- 만약 ImageId 를 받아오지 않을 경우에는, 사용자가 트윗 추가 또는 프로필 정보 수정 요청할 때에 로딩 상태를 표시해 줌.
   1. 해당 작업의 상태가 진행되는지의  boolean : 사용자가 버튼을 누를 때 true, api 요청을 보낸 후에 false로 변경
   6. api Loading 상태 boolean : 사용자가 api 요청을 하여, 트윗추가를 하거나 프로필 수정을 진행할때의 결과 로딩 boolean
   7. 두 가지중  하나라도 true 라면 loading indicator 를 보여줌

## 추가 작업

-  `useForm` 에서 빈 input value가 들어가는 것을 방지하기 위해 에러처리 추가함.
- pre-commit 훅에 타입체킹 추가