### PR TITLE
Feature #4 작성날짜 추가 및 Next Image Warning 제거

### DIFF
--- a/src/components/images/ProfileImage.tsx
+++ b/src/components/images/ProfileImage.tsx
@@ -11,6 +11,8 @@ export default function ProfileImage({ avatarId }: { avatarId: string | undefine
             alt="preview Image"
             className="object-cover overflow-hidden rounded-full"
             fill
+            priority
+            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
             src={makeImagePath(avatarId)}
           />
         </div>

--- a/src/components/images/TweetImage.tsx
+++ b/src/components/images/TweetImage.tsx
@@ -4,7 +4,14 @@ import Image from 'next/image';
 export default function TweetImage({ imageId }: { imageId: string }) {
   return (
     <div className="relative w-full my-3 h-60 ">
-      <Image alt={imageId} className="object-contain" fill src={makeImagePath(imageId)}></Image>
+      <Image
+        alt={imageId}
+        className="object-contain"
+        fill
+        priority
+        sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+        src={makeImagePath(imageId)}
+      ></Image>
     </div>
   );
 }

--- a/src/libs/client/formDate.ts
+++ b/src/libs/client/formDate.ts
@@ -1,0 +1,37 @@
+const ONE_MINUTE_MS = 1000 * 60;
+const ONE_HOUR_MS = ONE_MINUTE_MS * 60;
+const ONE_DAY_MS = ONE_HOUR_MS * 24;
+const ONE_WEEK_MS = ONE_DAY_MS * 7;
+
+const formatDate = (inputDate: Date | undefined) => {
+  if (!inputDate) return;
+
+  const createdAt = new Date(inputDate);
+
+  if (isNaN(createdAt.getTime())) {
+    return '잘못된 날짜 입니다.';
+  }
+
+  const createdAt_MS = createdAt.getTime();
+  const currentTime = Date.now();
+  const timeDifference = currentTime - createdAt_MS;
+
+  if (timeDifference < ONE_MINUTE_MS) {
+    return '방금전';
+  }
+  if (timeDifference < ONE_HOUR_MS) {
+    const minutes = Math.floor(timeDifference / ONE_MINUTE_MS);
+    return `${minutes}분 전`;
+  }
+  if (timeDifference < ONE_DAY_MS) {
+    const hours = Math.floor(timeDifference / ONE_HOUR_MS);
+    return `${hours}시간 전`;
+  }
+  if (timeDifference < ONE_WEEK_MS) {
+    const days = Math.floor(timeDifference / ONE_DAY_MS);
+    return `${days}일 전`;
+  }
+  return createdAt.toLocaleString(undefined, { day: '2-digit', month: '2-digit', year: 'numeric' });
+};
+
+export default formatDate;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import { Layout, LikeButton, LoadingSpinner, ProfileImage, Symbol, TweetImage } from '@/components';
 import { METHOD, ROUTE_PATH } from '@/constants';
 import { useMutation } from '@/libs/client';
+import formatDate from '@/libs/client/formDate';
 import maskEmail from '@/libs/client/maskEmail';
 import { ResponseType, TweetResponse } from '@/types';
 import { Like } from '@prisma/client';
@@ -48,6 +49,7 @@ export default function Home() {
                 <ProfileImage avatarId={tweet.user.profile?.avatar} />
                 <h3 className="text-xl font-bold">{tweet.user.name}</h3>
                 <small>{maskEmail(tweet.user.email)}</small>
+                <small className="ml-auto  text-stone-500">{formatDate(tweet.createdAt)}</small>
               </div>
               <Link className="px-5 mx-3" href={`${ROUTE_PATH.TWEETS}/${tweet.id}`}>
                 {tweet.image && <TweetImage imageId={tweet.image} />}

--- a/src/pages/profile/edit.tsx
+++ b/src/pages/profile/edit.tsx
@@ -17,7 +17,6 @@ type EditProfileInput = { bio: string; username: string };
 export default function ProfileEdit() {
   const router = useRouter();
   const { data: profile } = useSWR<ResponseType<ProfileResponse>>('/api/users/profile');
-  const [isLoading, setIsLoading] = useState(false);
   const [isEditedProfileSubmissionInProgress, setIsEditedProfileSubmissionInProgress] = useState(false);
 
   const { errorMessage, errors, form, isError, onChange } = useForm<EditProfileInput>(
@@ -82,6 +81,8 @@ export default function ProfileEdit() {
                 alt="preview Image"
                 className="object-cover w-full overflow-hidden rounded-full h-50 "
                 fill
+                priority
+                sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
                 src={previewImage}
               />
             </div>
@@ -91,6 +92,8 @@ export default function ProfileEdit() {
                 alt="preview Image"
                 className="object-cover w-full overflow-hidden rounded-full h-50 "
                 fill
+                priority
+                sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
                 src={makeImagePath(profile?.data?.profile?.avatar)}
               />
             </div>

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -24,6 +24,7 @@ export default function Profile() {
                     alt="preview Image"
                     className="object-cover w-full overflow-hidden rounded-full h-50 "
                     fill
+                    sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
                     src={makeImagePath(profile?.data?.profile?.avatar)}
                   />
                 </div>

--- a/src/pages/tweet/[id].tsx
+++ b/src/pages/tweet/[id].tsx
@@ -3,6 +3,7 @@ import { METHOD, ROUTE_PATH } from '@/constants';
 import { useForm } from '@/hooks';
 import useDelete from '@/hooks/useDelete';
 import { useMutation } from '@/libs/client';
+import formatDate from '@/libs/client/formDate';
 import maskEmail from '@/libs/client/maskEmail';
 import { basicTextValidator } from '@/libs/client/validators';
 import { db, withSsrSession } from '@/libs/server';
@@ -60,6 +61,7 @@ export default function DetailTweet({ loggedInUser }: LoggedInUsr) {
       );
     }
   };
+
   const { errorMessage, form, isError, onChange, reset } = useForm<UploadBasicInputText>(
     { text: '' },
     { text: basicTextValidator }
@@ -128,12 +130,13 @@ export default function DetailTweet({ loggedInUser }: LoggedInUsr) {
             <ProfileImage avatarId={responseTweet?.data?.user.profile?.avatar} />
             <h3 className="text-xl font-bold">{responseTweet?.data?.user.name}</h3>
             <small>{maskEmail(responseTweet?.data?.user.email || '')}</small>
+            <small className="ml-auto text-stone-500">{formatDate(responseTweet?.data?.createdAt)}</small>
             {loggedInUser.id === responseTweet?.data?.userId && (
               <AiOutlineDelete
                 onClick={() =>
                   tweetDelete(String(router.query.id) || responseTweet?.data?.id, `/api/tweets/${router.query.id}`)
                 }
-                className="absolute cursor-pointer right-3"
+                className="cursor-pointer "
                 size={30}
               />
             )}
@@ -170,7 +173,8 @@ export default function DetailTweet({ loggedInUser }: LoggedInUsr) {
               <div className="flex items-center gap-2 " key={comment.id}>
                 <ProfileImage avatarId={comment.user.profile?.avatar} />
                 <span className="w-1/6 font-semibold">{comment.user.name}</span>
-                <span className="w-3/5">{comment.text}</span>
+                <span className="w-1/2">{comment.text}</span>
+                <small className="ml-auto w-fit text-stone-500">{formatDate(comment.createdAt)}</small>
                 {loggedInUser.id === comment.user.id && (
                   <AiOutlineDelete
                     className="cursor-pointer fill-stone-400"

--- a/src/pages/tweet/upload.tsx
+++ b/src/pages/tweet/upload.tsx
@@ -60,7 +60,13 @@ export default function Upload() {
         >
           <input accept="image/*" className="hidden" id="image" name="image" onChange={selectedImage} type="file" />
           {previewImage ? (
-            <Image alt="preview Image" className="object-contain w-full h-60 " fill src={previewImage} />
+            <Image
+              alt="preview Image"
+              className="object-contain w-full h-60 "
+              fill
+              sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+              src={previewImage}
+            />
           ) : (
             <div className="r">
               <AiOutlinePicture className="text-beige3" size={80} />


### PR DESCRIPTION
# Feature
- 작성날짜 추가
- Next Image Warning 제거

Closes #4 

# Description
1. 트윗, 코멘트의 작성날짜를 보여준다.
- '방금전', '0분 전' , '0시간 전' , '0일 전', '작성 날짜' 순으로 표기
2. Next Image warning 제거 :
- fill 사용시 sizes 추가; 
   - warning message :  Image with src "이미지 src" has "fill" but is missing "sizes" prop. Please add it to improve page performance.
- priority 추가 ;
  - warning message  Image with src "이미지" was detected as the Largest Contentful Paint (LCP). Please add the "priority" property if this image is above the fold.