### PR TITLE
Feature #6 세션쿠키 만료설정

### DIFF
--- a/src/libs/server/withSession.ts
+++ b/src/libs/server/withSession.ts
@@ -11,6 +11,9 @@ declare module 'iron-session' {
 
 const cookieOptions = {
   cookieName: 'dam-witter',
+  cookieOptions: {
+    maxAge: undefined,
+  },
   password: process.env.COOKIE_PASSWORD as string,
 };
 


### PR DESCRIPTION
# Feature
- 세션쿠키 만료설정

Closes #6 

# Description
-  iron-session 의 [README](https://github.com/vvo/iron-session#session-cookies) 참고 
- 세션쿠키 만료설정 : 브라우저 종료시 세션쿠키를 제거함
- ttl 옵션 또는 maxAge 옵션을 사용하여 세션쿠키 만료기간을 설정하고 자동로그아웃 기능을 만들 수 있지만, 사용자에게 자동로그인 카운트다운 시간을 알려주지 않고 있다는 점에서 브라우저 종료시 세션쿠키를 제거하는 방향으로 구현.
- 