### PR TITLE
Feature #24 삭제 권한 취약점 문제 해결

### DIFF
--- a/src/pages/api/tweets/[id]/comments/[commentId].ts
+++ b/src/pages/api/tweets/[id]/comments/[commentId].ts
@@ -9,6 +9,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType<Co
       query: { commentId, id },
       session: { user },
     } = req;
+
     const existComment = await db.comment.findFirst({
       where: {
         id: String(commentId),
@@ -16,6 +17,9 @@ async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType<Co
         userId: user?.id,
       },
     });
+    if (user?.id == existComment?.userId)
+      return res.status(401).json({ data: null, isSuccess: false, message: '권한이 없습니다.', statusCode: 401 });
+
     if (!existComment)
       return res
         .status(404)
@@ -26,7 +30,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType<Co
         id: existComment.id,
       },
     });
-    return res.status(200).json({ data: null, isSuccess: true, message: '삭제되었습니다.', statusCode: 204 });
+    return res.status(204).json({ data: null, isSuccess: true, message: '삭제되었습니다.', statusCode: 204 });
   }
 }
 

--- a/src/pages/api/tweets/[id]/index.ts
+++ b/src/pages/api/tweets/[id]/index.ts
@@ -75,4 +75,4 @@ async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType<Tw
   }
 }
 
-export default withApiSession(withHandler({ handler, methods: [METHOD.GET, METHOD.DELETE] }));
+export default withApiSession(withHandler({ handler, isPrivate: true, methods: [METHOD.GET, METHOD.DELETE] }));

--- a/src/pages/api/tweets/[id]/index.ts
+++ b/src/pages/api/tweets/[id]/index.ts
@@ -63,12 +63,15 @@ async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType<Tw
   }
 
   if (req.method === METHOD.DELETE) {
+    if (user?.id !== tweet.userId)
+      return res.status(401).json({ data: null, isSuccess: false, message: '권한이 없습니다.', statusCode: 401 });
+
     await db.tweet.delete({
       where: {
         id: tweet.id,
       },
     });
-    return res.status(200).json({ data: tweet, isSuccess: true, message: '삭제 되었습니다.', statusCode: 204 });
+    return res.status(204).json({ data: tweet, isSuccess: true, message: '삭제 되었습니다.', statusCode: 204 });
   }
 }
 

--- a/src/pages/api/tweets/[id]/like.ts
+++ b/src/pages/api/tweets/[id]/like.ts
@@ -83,4 +83,4 @@ async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType<Li
   }
 }
 
-export default withApiSession(withHandler({ handler, methods: [METHOD.POST, METHOD.DELETE] }));
+export default withApiSession(withHandler({ handler, isPrivate: true, methods: [METHOD.POST, METHOD.DELETE] }));

--- a/src/pages/api/tweets/index.ts
+++ b/src/pages/api/tweets/index.ts
@@ -106,4 +106,4 @@ async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType<Tw
       .json({ data: [newTweet, ...transformedTweets], isSuccess: true, message: '추가 되었습니다.', statusCode: 201 });
   }
 }
-export default withApiSession(withHandler({ handler, methods: [METHOD.GET, METHOD.POST] }));
+export default withApiSession(withHandler({ handler, isPrivate: true, methods: [METHOD.GET, METHOD.POST] }));


### PR DESCRIPTION
# Feature
-  삭제 권한 취약점 문제 해결

Closes #24

# Description
## 작성자가 아닌 다른 사용자도 api 를 직접 호출하면 트윗과 코멘트를 삭제할 수 있는 문제점 
- 작성자와 로그인한 사용자가 동일하지 않을 경우 `권한 없음`의 에러를 반환합니다.
<img width="1013" alt="image" src="https://github.com/j2h30728/dam-witter/assets/60846068/3a46e65f-498e-492c-a26c-e5019e17aa05">

## 외부에서 api 를 조작할 수 있는 문제점
- 로그인한 사용자만 tweets 관련 api를 사용할 수 있게 설정을 변경합니다.
- 세션에 use.id가 존재하지 않는다면 api를 부를 수 없습니다.

<img width="978" alt="image" src="https://github.com/j2h30728/dam-witter/assets/60846068/1ed9b541-7762-4245-ac61-20190b48ee05">

