### PR TITLE
Feature #26 트윗 및 코멘트 삭제 기능 관련 문제 해결

### DIFF
--- a/src/components/comments/index.tsx
+++ b/src/components/comments/index.tsx
@@ -27,7 +27,10 @@ const Comments = ({
     `/api/tweets/${router.query.id}/comments`,
     fetchers.post<UploadBasicInputText, CommentResponse>
   );
-  const deleteComment = useSWRMutation(`/api/tweets/${router.query.id}/comments`, fetchers.delete);
+  const deleteComment = useSWRMutation(`/api/tweets/${router.query.id}/comments`, fetchers.delete, {
+    revalidate: false,
+    rollbackOnError: true,
+  });
 
   const handleUploadComment = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/src/pages/api/tweets/[id]/comments/[commentId].ts
+++ b/src/pages/api/tweets/[id]/comments/[commentId].ts
@@ -17,7 +17,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType<Co
         userId: user?.id,
       },
     });
-    if (user?.id == existComment?.userId)
+    if (user?.id !== existComment?.userId)
       return res.status(401).json({ data: null, isSuccess: false, message: '권한이 없습니다.', statusCode: 401 });
 
     if (!existComment)

--- a/src/pages/api/tweets/[id]/index.ts
+++ b/src/pages/api/tweets/[id]/index.ts
@@ -71,7 +71,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType<Tw
         id: tweet.id,
       },
     });
-    return res.status(204).json({ data: tweet, isSuccess: true, message: '삭제 되었습니다.', statusCode: 204 });
+    return res.status(200).json({ data: null, isSuccess: true, message: '삭제 되었습니다.', statusCode: 200 });
   }
 }
 

--- a/src/pages/tweet/[id].tsx
+++ b/src/pages/tweet/[id].tsx
@@ -23,11 +23,12 @@ function TweetAndComments() {
     onError: (error: string) => toastMessage('error', error),
     onSuccess: data => {
       if (data.isSuccess) {
-        mutate('/api/tweets', () => fetch('/api/tweets'));
         router.replace(ROUTE_PATH.HOME);
+        mutate('/api/tweets', () => fetch('/api/tweets'));
       }
       toastMessage('info', data.message);
     },
+    revalidate: false,
   });
 
   const debouncedToggleLike = useDebounce((tweetIsLiked: boolean) => {

--- a/src/pages/tweet/[id].tsx
+++ b/src/pages/tweet/[id].tsx
@@ -23,8 +23,8 @@ function TweetAndComments() {
     onError: (error: string) => toastMessage('error', error),
     onSuccess: data => {
       if (data.isSuccess) {
-        router.replace(ROUTE_PATH.HOME);
         mutate('/api/tweets', () => fetch('/api/tweets'));
+        router.replace(ROUTE_PATH.HOME);
       }
       toastMessage('info', data.message);
     },


### PR DESCRIPTION
# Feature
-  트윗 및 코멘트 삭제 기능 관련 문제 해결

Closes #26

# Description
## 트윗 작성자가 트윗 삭제 버튼을 누르면 트윗은 삭제되지만, 이후 진행되어야하는 작업이 되지 않는 문제점
- Tweet api에서 트윗이 삭제될 경우 status code 가 204 였기 때문에 client에서 응답값을 받지 못하는 문제가 발생하였습니다. status code를 200으로 수정합니다.
    `return res.status(200).json({ data: null, isSuccess: true, message: '삭제 되었습니다.', statusCode: 200 });`

## 코멘트 작성자가 삭제기능을 사용시 에러가 반환 되는 문제점
- 누락된 ! (부정 연산자)를 추가해주어, 엄격한 부등 연산자로 수정하였습니다.
```js
    if (user?.id !== existComment?.userId)
      return res.status(401).json({ data: null, isSuccess: false, message: '권한이 없습니다.', statusCode: 401 });
```

# Additional context
트윗과 코멘트를 삭제한 이후에 revalidate 를 시키지 않습니다.
- 트윗은 DELETE 요청 이후, 삭제된 tweet api 를 부르게 되면 에러가 반환되는 것을 막기 위합니다.
- 현재, 코멘트 삭제는 낙관적 업데이트 적용이 되어있습니다. 이와 동일하게 코멘트 삭제가 완료 되어도 revalidate를 시키지않으며 에러가 발생될 경우에만 rollvack을 적용합니다.
