### PR TITLE
Feature #30 트윗 업로드와 삭제 중에 대한 문제점 보완

### DIFF
--- a/src/pages/api/tweets/[id]/comments/[commentId].ts
+++ b/src/pages/api/tweets/[id]/comments/[commentId].ts
@@ -30,7 +30,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType<Co
         id: existComment.id,
       },
     });
-    return res.status(204).json({ data: null, isSuccess: true, message: '삭제되었습니다.', statusCode: 204 });
+    return res.status(200).json({ data: null, isSuccess: true, message: '삭제되었습니다.', statusCode: 200 });
   }
 }
 

--- a/src/pages/tweet/[id].tsx
+++ b/src/pages/tweet/[id].tsx
@@ -9,13 +9,15 @@ import { toastMessage } from '@/libs/client/toastMessage';
 import { ProfileResponse, ResponseType, TweetResponse } from '@/types';
 import { useRouter } from 'next/router';
 import useSWR from 'swr';
-import { mutate } from 'swr/_internal';
+import { cache } from 'swr/_internal';
 import useSWRMutation from 'swr/mutation';
 
 function TweetAndComments() {
   const router = useRouter();
 
-  const tweet = useSWR<ResponseType<TweetResponse>>(router.query.id ? `/api/tweets/${router.query.id}` : null);
+  const tweet = useSWR<ResponseType<TweetResponse>>(router.query.id ? `/api/tweets/${router.query.id}` : null, {
+    revalidateOnFocus: false,
+  });
   const { data: loggedInUser } = useSWR<ResponseType<ProfileResponse>>('/api/users/profile');
   const toggleLike = useLikeTweet();
 
@@ -23,7 +25,7 @@ function TweetAndComments() {
     onError: (error: string) => toastMessage('error', error),
     onSuccess: data => {
       if (data.isSuccess) {
-        mutate('/api/tweets', () => fetch('/api/tweets'));
+        cache.delete('/api/tweets');
         router.replace(ROUTE_PATH.HOME);
       }
       toastMessage('info', data.message);
@@ -70,7 +72,7 @@ function TweetAndComments() {
   if (tweet.isLoading || !tweet.data || !loggedInUser?.data) {
     return <LoadingSpinner text={'불러오는 중..'} />;
   }
-  if (tweetDelete.isMutating || tweetDelete.data) {
+  if (tweetDelete.isMutating || tweetDelete.data?.isSuccess) {
     return <LoadingSpinner text="트윗 삭제 중 입니다." />;
   }
 

--- a/src/pages/tweet/[id].tsx
+++ b/src/pages/tweet/[id].tsx
@@ -19,6 +19,7 @@ function TweetAndComments() {
     revalidateOnFocus: false,
   });
   const { data: loggedInUser } = useSWR<ResponseType<ProfileResponse>>('/api/users/profile');
+
   const toggleLike = useLikeTweet();
 
   const tweetDelete = useSWRMutation(`/api/tweets/${router.query.id}`, fetchers.delete, {

--- a/src/pages/tweet/[id].tsx
+++ b/src/pages/tweet/[id].tsx
@@ -18,8 +18,9 @@ function TweetAndComments() {
   const tweet = useSWR<ResponseType<TweetResponse>>(router.query.id ? `/api/tweets/${router.query.id}` : null, {
     revalidateOnFocus: false,
   });
-  const { data: loggedInUser } = useSWR<ResponseType<ProfileResponse>>('/api/users/profile');
-
+  const { data: loggedInUser } = useSWR<ResponseType<ProfileResponse>>('/api/users/profile', {
+    revalidateOnFocus: false,
+  });
   const toggleLike = useLikeTweet();
 
   const tweetDelete = useSWRMutation(`/api/tweets/${router.query.id}`, fetchers.delete, {


### PR DESCRIPTION
# Feature
-   트윗 업로드와 삭제 중에 대한 문제점 보완

Closes #30

# Description

## 문제점 및 해결 내용

### 1. 트윗 업로드 중, 트윗 리스트 데이터를 새로 가져오는 잠깐의 시기에서 업로드 버튼 비활성화 버튼이 풀린다.
- 업로드 성공 이후, 트윗 리스트 데이터를 다시 페칭하여 캐싱하는 순간에 일어나는 문제점이다.
- 업로드하는 트윗의 mutate 결과데이터 반환값이 성공일때에도 업로드 페이지에서 사용자가 접근할 수 있는 버튼을 모두 비활성화 시킨다.

### 2. 트윗 삭제 후, 직전에 삭제한 트윗이 트윗리스트에 보여진다.
#### 변경 이전
- 트윗 삭제가 성공하면 트윗 리스트 데이터를 다시 페칭하여 캐싱작업을 진행한다.
#### 변경 이후
- 트윗 삭제가 성공하면 캐싱되어있는 트윗 리스트 데이터를 삭제한다. 
- 그 후, 트윗 리스트 페이지로 이동하여 해당 페이지에서 다시 트윗 리스트를 페칭한다. 
- `revalidateOnFocus: false,`옵션을 사용하여 사용자가 트윗 페이지에서 상호작용을 하여도 해당 트윗 상세 내용을 다시 가져오지않도록 설정함
    ```ts
  const tweet = useSWR<ResponseType<TweetResponse>>(router.query.id ? `/api/tweets/${router.query.id}` : null, {
    revalidateOnFocus: false,
  });
    ```

# Additional context

 comment 삭제시 status code 를 204로 반환하는 comment API를 200 code로 변경