### PR TITLE
Feature #32 트윗 리스트를 무한 스크롤 구현

### DIFF
--- a/src/hooks/useInfiniteScrollData.ts
+++ b/src/hooks/useInfiniteScrollData.ts
@@ -1,0 +1,23 @@
+import useSWRInfinite from 'swr/infinite';
+
+import useIntersectionObserver from './useIntersectionObserver';
+
+const PAGE_SIZE = 10;
+
+const getKey = <T>(index: number, previousPageData: T[] | null, url: string) => {
+  if (previousPageData && previousPageData.length === 0) return null;
+  return `${url}?pageIndex=${index}&limit=${PAGE_SIZE}`;
+};
+
+const useInfiniteScrollData = <T>(url: string) => {
+  const { data, isLoading, isValidating, mutate, setSize, size } = useSWRInfinite<T[]>((...args) =>
+    getKey(...args, url)
+  );
+  const { bottomItemRef } = useIntersectionObserver(() => setSize(size => size + 1));
+
+  const flattedData = data?.flat() ?? [];
+
+  return { bottomItemRef, data: flattedData, isLoading, isValidating, mutate, setSize };
+};
+
+export default useInfiniteScrollData;

--- a/src/hooks/useInfiniteScrollData.ts
+++ b/src/hooks/useInfiniteScrollData.ts
@@ -2,7 +2,7 @@ import useSWRInfinite from 'swr/infinite';
 
 import useIntersectionObserver from './useIntersectionObserver';
 
-const PAGE_SIZE = 10;
+export const PAGE_SIZE = 10;
 
 const getKey = <T>(index: number, previousPageData: T[] | null, url: string) => {
   if (previousPageData && previousPageData.length === 0) return null;

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -1,0 +1,32 @@
+import { useCallback, useRef } from 'react';
+
+function useIntersectionObserver<T extends HTMLElement>(callback: () => void) {
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const bottomItemRef = useCallback(
+    (node: T | null) => {
+      if (observerRef.current) {
+        observerRef.current.disconnect();
+      }
+
+      observerRef.current = new IntersectionObserver(
+        entries => {
+          if (entries[0].isIntersecting) {
+            callback();
+          }
+        },
+        { threshold: 0.1 }
+      );
+
+      if (node) {
+        observerRef.current.observe(node);
+      }
+    },
+    [callback]
+  );
+
+  return {
+    bottomItemRef,
+  };
+}
+
+export default useIntersectionObserver;

--- a/src/pages/api/tweets/index.ts
+++ b/src/pages/api/tweets/index.ts
@@ -7,6 +7,11 @@ import { NextApiRequest, NextApiResponse } from 'next';
 
 async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType<TweetResponse | TweetResponse[]>>) {
   const { user } = req.session;
+  const { limit, pageIndex } = req.query;
+
+  const skip = Number(pageIndex ?? 0) * (Number(limit) ?? 10);
+  const take = Number(limit) ?? 10;
+
   const tweets = await db.tweet.findMany({
     include: {
       _count: {
@@ -32,6 +37,8 @@ async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType<Tw
     orderBy: {
       createdAt: 'desc',
     },
+    skip,
+    take,
   });
   const transformedTweets = tweets.map(tweet => ({
     ...tweet,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,25 +2,23 @@ import { Layout, LikeButton, LoadingSpinner, ProfileImage, Symbol, TweetImage } 
 import { METHOD, ROUTE_PATH } from '@/constants';
 import useLikeTweet from '@/hooks/tweets/useLikeTweet';
 import useDebounce from '@/hooks/useDebounce';
+import useGetInfiniteData from '@/hooks/useInfiniteScrollData';
 import { formatDate, maskEmail } from '@/libs/client';
 import { db, withSsrSession } from '@/libs/server';
 import { ResponseType, TweetResponse } from '@/types';
 import { GetServerSidePropsContext, NextPage } from 'next';
 import Link from 'next/link';
-import useSWR, { SWRConfig } from 'swr';
+import { SWRConfig } from 'swr';
 
 const Home: NextPage = () => {
-  const {
-    data: responseTweets,
-    isLoading,
-    mutate: tweetsMutate,
-  } = useSWR<ResponseType<TweetResponse[]>>('/api/tweets');
+  const { bottomItemRef, data, isLoading, isValidating, mutate } =
+    useGetInfiniteData<ResponseType<TweetResponse[]>>('/api/tweets');
 
   const { trigger: toggleLike } = useLikeTweet();
 
   const debouncedToggleLike = useDebounce((tweet: TweetResponse) => {
     if (responseTweets) {
-      responseTweets.data?.forEach(responseTweet => {
+      responseTweets?.forEach(responseTweet => {
         if (responseTweet.id === tweet.id) {
           toggleLike(
             { method: responseTweet.isLiked ? METHOD.DELETE : METHOD.POST, tweetId: responseTweet.id },
@@ -34,32 +32,31 @@ const Home: NextPage = () => {
   const handleLikeToggle = (tweet: TweetResponse) => {
     debouncedToggleLike(tweet);
 
-    if (responseTweets)
-      tweetsMutate(
-        {
-          ...responseTweets,
-          data:
-            responseTweets.data?.map(t => {
-              if (t.id === tweet.id) {
-                let newLikeStatus = !t.isLiked;
-                let newLikeCount = newLikeStatus ? t._count.likes + 1 : t._count.likes - 1;
-                return { ...t, _count: { ...t._count, likes: newLikeCount }, isLiked: newLikeStatus };
-              } else {
-                return t;
-              }
-            }) || [],
-        },
-        false
-      );
+    // TODO infinite scroll 기준으로 좋아요 낙관적 업데이트 적용
+    if (responseTweets) mutate();
+    // {
+    //   ...responseTweets,
+    //   data:
+    //     responseTweets.data?.map(t => {
+    //       if (t.id === tweet.id) {
+    //         let newLikeStatus = !t.isLiked;
+    //         let newLikeCount = newLikeStatus ? t._count.likes + 1 : t._count.likes - 1;
+    //         return { ...t, _count: { ...t._count, likes: newLikeCount }, isLiked: newLikeStatus };
+    //       } else {
+    //         return t;
+    //       }
+    //     }) || [],
+    // },
+    // false
   };
 
   if (isLoading) {
     return <LoadingSpinner text={'불러오는 중..'} />;
   }
-
+  const responseTweets = data.flatMap(tweet => tweet.data) as TweetResponse[];
   return (
     <div className="gap-5 sub-layout">
-      {responseTweets?.data?.map((tweet: TweetResponse) => (
+      {responseTweets.map((tweet: TweetResponse) => (
         <div className="flex flex-col gap-4 pb-2 border-b-2 border-base1" key={tweet.id}>
           <div className="flex items-center gap-3 px-3">
             <ProfileImage avatarId={tweet.user.profile?.avatar} />
@@ -89,6 +86,7 @@ const Home: NextPage = () => {
           </div>
         </div>
       ))}
+      {isValidating ? <LoadingSpinner text={'불러오는 중..'} /> : <div ref={bottomItemRef}>마지막</div>}
     </div>
   );
 };


### PR DESCRIPTION
# Feature
- 메인페이지에서 렌더되는 트윗 리스트를 무한 스크롤로 구현한다.

Closes #32  

# Description
### tweets API 에서 무한 스크롤링이 가능한 페이지단위로 반환
- prisma 의 skip과 take를 사용하여 데이터베이스에서 10개씩 데이터를 가져온다.
- https://www.prisma.io/docs/orm/prisma-client/queries/pagination

### 메인페이지에서 트윗리스트를 무한 스크롤로 렌더하는 것으로 변경
|scroll event|Intersection observer API|
|-|-|
|스크롤 이벤트가 일어 나고 뷰포트 높이와 스크롤 높이(문서상단에서 현재 스크롤된 높이까지의 거리)의 합이 전체문서의 높이보다 클 경우 다음 페이지의 데이터값을 불러온다.</br><br/> 하지만, scrolltop(스크롤 높이)과 offsetHeight(전체문서 높이) 를 참조하는 방식은 리플로우를 다시 일으켜서 참조값을 업데이트 할 수 도있다.<br/> throttle을 사용하여 스크롤이 발생할 때, 일정 시간마다 스크롤 이벤트를 일으키는 것으로  최적화가 가능하다. |브라우저 뷰포트와 설정한 타겟의 교차점을 확인해서 타겟이 뷰포트에 포함될때 다음 페이지의 데이터 값을 불러온다.  |

- 스크롤 이벤트의 리플로우의 단점으로 인하여 Intersection observer API 채택한다.
- Intersection Observer를 사용하여 마지막 타켓이 뷰포트에 포함되는지 감지하고 추가적인 데이터를 가져오는 무한 스크롤 방식으로 구현한다.


### 무한 스크롤로 렌더되는 tweet들의 좋아요 낙관적 업데이트를 적용
- https://swr.vercel.app/ko/docs/pagination