### PR TITLE
Feature #34 트윗 리스트를 무한 스크롤 구현 2 (보완)

### DIFF
--- a/src/components/common/LoadingSpinner.tsx
+++ b/src/components/common/LoadingSpinner.tsx
@@ -1,6 +1,6 @@
 export default function LoadingSpinner({ text }: { text?: String }) {
   return (
-    <div className="flex flex-col gap-5 items-center justify-center w-full h-[600px]">
+    <div className="flex flex-col items-center justify-center w-full h-full gap-5 mt-5">
       <div className="w-16 h-16 border-t-4 border-b-4 border-gray-900 rounded-full animate-spin"></div>
       <span>{text}</span>
     </div>

--- a/src/hooks/useInfiniteScrollData.ts
+++ b/src/hooks/useInfiniteScrollData.ts
@@ -1,3 +1,4 @@
+import { ResponseType } from '@/types';
 import useSWRInfinite from 'swr/infinite';
 
 import useIntersectionObserver from './useIntersectionObserver';
@@ -10,12 +11,17 @@ const getKey = <T>(index: number, previousPageData: T[] | null, url: string) => 
 };
 
 const useInfiniteScrollData = <T>(url: string) => {
-  const { data, isLoading, isValidating, mutate, setSize, size } = useSWRInfinite<T[]>((...args) =>
+  const { data, isLoading, isValidating, mutate, setSize, size } = useSWRInfinite<ResponseType<T[]>[]>((...args) =>
     getKey(...args, url)
   );
-  const { bottomItemRef } = useIntersectionObserver(() => setSize(size => size + 1));
-
   const flattedData = data?.flat() ?? [];
+
+  const isEmpty = flattedData.at(0)?.data?.length === 0;
+  const isLastPage = (flattedData.at(-1)?.data?.length ?? 0) < PAGE_SIZE;
+
+  const { bottomItemRef } = useIntersectionObserver(() => {
+    if (!isEmpty && !isLastPage) setSize(size => size + 1);
+  });
 
   return { bottomItemRef, data: flattedData, isLoading, isValidating, mutate, setSize };
 };

--- a/src/hooks/useInfiniteScrollData.ts
+++ b/src/hooks/useInfiniteScrollData.ts
@@ -7,11 +7,12 @@ export const PAGE_SIZE = 10;
 
 const getKey = <T>(index: number, previousPageData: T[] | null, url: string) => {
   if (previousPageData && previousPageData.length === 0) return null;
+  if (index === 0) return url;
   return `${url}?pageIndex=${index}&limit=${PAGE_SIZE}`;
 };
 
 const useInfiniteScrollData = <T>(url: string) => {
-  const { data, isLoading, isValidating, mutate, setSize, size } = useSWRInfinite<ResponseType<T[]>[]>((...args) =>
+  const { data, isLoading, isValidating, mutate, setSize } = useSWRInfinite<ResponseType<T[]>[]>((...args) =>
     getKey(...args, url)
   );
   const flattedData = data?.flat() ?? [];

--- a/src/pages/api/tweets/index.ts
+++ b/src/pages/api/tweets/index.ts
@@ -9,8 +9,8 @@ async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType<Tw
   const { user } = req.session;
   const { limit, pageIndex } = req.query;
 
-  const skip = Number(pageIndex ?? 0) * (Number(limit) ?? 10);
-  const take = Number(limit) ?? 10;
+  const take = Number(limit ?? 10);
+  const skip = Number(pageIndex ?? 0) * take;
 
   const tweets = await db.tweet.findMany({
     include: {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,8 +11,7 @@ import Link from 'next/link';
 import { SWRConfig } from 'swr';
 
 const Home: NextPage = () => {
-  const { bottomItemRef, data, isLoading, isValidating, mutate } =
-    useGetInfiniteData<ResponseType<TweetResponse[]>>('/api/tweets');
+  const { bottomItemRef, data, isLoading, isValidating, mutate } = useGetInfiniteData<TweetResponse>('/api/tweets');
 
   const { trigger: toggleLike } = useLikeTweet();
   const responseTweets = data.flatMap(tweet => tweet.data) as TweetResponse[];

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -84,7 +84,7 @@ const Home: NextPage = () => {
           </div>
         </div>
       ))}
-      {isValidating ? <LoadingSpinner text={'불러오는 중..'} /> : <div ref={bottomItemRef}>마지막</div>}
+      {isValidating ? <LoadingSpinner text={'불러오는 중..'} /> : <div ref={bottomItemRef}></div>}
     </div>
   );
 };

--- a/src/pages/tweet/[id].tsx
+++ b/src/pages/tweet/[id].tsx
@@ -22,11 +22,11 @@ function TweetAndComments() {
     revalidateOnFocus: false,
   });
   const toggleLike = useLikeTweet();
-
   const tweetDelete = useSWRMutation(`/api/tweets/${router.query.id}`, fetchers.delete, {
     onError: (error: string) => toastMessage('error', error),
     onSuccess: data => {
       if (data.isSuccess) {
+        cache.delete('$inf$/api/tweets');
         cache.delete('/api/tweets');
         router.replace(ROUTE_PATH.HOME);
       }


### PR DESCRIPTION
# Feature
- 구현된 무한스크롤 기능을 보완한다. (#33 보완)

Closes #34 

# Description
###  마지막 페이지의 데이터일 경우에는 더이상 페칭하지않는다.
- 데이터가 존재하지 않거나, 마지막 페이지 일 경우에는 size 변화를 주지않고 더이상 페칭하지 않는다.
    ```ts
  const isEmpty = flattedData.at(0)?.data?.length === 0;
  const isLastPage = (flattedData.at(-1)?.data?.length ?? 0) < PAGE_SIZE;

  const { bottomItemRef } = useIntersectionObserver(() => {
    if (!isEmpty && !isLastPage) setSize(size => size + 1);
  });

### 무한스크롤에 맞는 로딩 스피너를 적용한다.
- 이미 존재하는 로딩 스피너의 높이 변경