### PR TITLE
Feature #39 useForm 커스텀 훅 보완하기

### DIFF
--- a/src/hooks/auth/useCreateAccount.ts
+++ b/src/hooks/auth/useCreateAccount.ts
@@ -11,7 +11,7 @@ interface CreateAccount extends UserInput {
 }
 
 const useCreateAccount = () => {
-  const { errorMessage, errors, form, isError, onChange } = useForm<CreateAccount>(
+  const { errorMessage, form, getErrorMessage, isError, onChange } = useForm<CreateAccount>(
     {
       confirmPassword: '',
       email: '',
@@ -42,10 +42,10 @@ const useCreateAccount = () => {
   return {
     form: {
       isError: {
-        confirmPassword: form.confirmPassword && !errors.confirmPassword.isValid && errors.confirmPassword.message,
-        email: form.email && !errors.email.isValid && errors.email.message,
-        name: form.name && !errors.name.isValid && errors.name.message,
-        password: form.password && !errors.password.isValid && errors.password.message,
+        confirmPassword: getErrorMessage('confirmPassword'),
+        email: getErrorMessage('email'),
+        name: getErrorMessage('name'),
+        password: getErrorMessage('password'),
       },
       onChange,
       values: form,

--- a/src/hooks/auth/useLogIn.ts
+++ b/src/hooks/auth/useLogIn.ts
@@ -9,7 +9,7 @@ import useForm from '../common/useForm';
 const useLogIn = () => {
   const { isLoginMutating, mutateLogIn } = useLoginMutation();
 
-  const { errorMessage, errors, form, isError, onChange } = useForm<Pick<UserInput, 'email' | 'password'>>(
+  const { errorMessage, form, getErrorMessage, isError, onChange } = useForm<Pick<UserInput, 'email' | 'password'>>(
     { email: '', password: '' },
     { email: emailValidator, password: passwordValidator }
   );
@@ -22,10 +22,9 @@ const useLogIn = () => {
 
   return {
     form: {
-      isError: {
-        email: form.email && !errors.email.isValid && errors.email.message,
-        name: form.name && !errors.name.isValid && errors.name.message,
-        password: form.password && !errors.password.isValid && errors.password.message,
+      errorMessage: {
+        email: getErrorMessage('email'),
+        password: getErrorMessage('password'),
       },
       onChange,
       values: form,

--- a/src/hooks/common/useForm.ts
+++ b/src/hooks/common/useForm.ts
@@ -1,15 +1,16 @@
 import { useState } from 'react';
 
-type Validator = (
+type Validator<T> = (
   value: React.InputHTMLAttributes<HTMLInputElement | HTMLTextAreaElement>['value'],
-  subValue?: Record<string, any>
-) => Errors;
-type Errors = { isValid: boolean; message: string };
-type NewError = Record<string, Errors>;
+  entryValues?: T
+) => ValidationField;
+type ValidationField = { isValid: boolean; message: string };
 
-function useForm<T extends Record<string, any>>(initialForm: T, validators: Record<string, Validator>) {
-  const [form, setForm] = useState<Record<string, string>>(initialForm);
-  const [errors, setErrors] = useState<Record<string, Errors>>(
+function useForm<T extends Record<string, any>>(initialForm: T, validators: { [K in keyof T]: Validator<T> }) {
+  type ValidatedResult = { [K in keyof T]: ValidationField };
+
+  const [form, setForm] = useState<T>(initialForm);
+  const [validatedResult, setValidatedResult] = useState<ValidatedResult>(
     Object.keys(initialForm).reduce(
       (acc, key) => ({
         ...acc,
@@ -17,34 +18,37 @@ function useForm<T extends Record<string, any>>(initialForm: T, validators: Reco
           ? { isValid: true, message: '' }
           : { isValid: false, message: `${key}의 입력값을 채워주세요.` },
       }),
-      {}
+      {} as ValidatedResult
     )
   );
 
   const onChange = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = event.target;
+
     setForm(prevForm => {
       const updatedForm = { ...prevForm, [name]: value };
-      const newErrors: NewError = {};
-      Object.entries(updatedForm).forEach(([fieldName, fieldValue]) => {
-        if (validators[fieldName]) {
-          newErrors[fieldName] = validators[fieldName](fieldValue, updatedForm);
-        }
-      });
-      setErrors(newErrors);
+
+      const newValidatedResult: ValidatedResult = {
+        ...validatedResult,
+        [name]: validators[name](value, updatedForm),
+      };
+      setValidatedResult(newValidatedResult);
       return updatedForm;
     });
   };
   const reset = () => setForm(initialForm);
 
-  const errorMessage = Object.values(errors)
+  const errorMessage = Object.values(validatedResult)
     .filter(error => !error.isValid)
     .map(error => error.message)
     .filter(error => error);
 
   const isError = errorMessage.length > 0;
 
-  return { errorMessage, errors, form, isError, onChange, reset };
+  const getErrorMessage = (key: keyof typeof form) => {
+    return form[key] && !validatedResult[key].isValid ? validatedResult[key].message : '';
+  };
+  return { errorMessage, form, getErrorMessage, isError, onChange, reset, validatedResult };
 }
 
 export default useForm;

--- a/src/hooks/tweets/useUploadTweet.ts
+++ b/src/hooks/tweets/useUploadTweet.ts
@@ -13,7 +13,7 @@ const useUploadTweet = () => {
 
   const { createdTweet, isUploadTweetMutating, uploadTweetMutate } = useTweetMutation();
 
-  const { errorMessage, errors, form, isError, onChange } = useForm<UploadBasicInputText>(
+  const { errorMessage, form, getErrorMessage, isError, onChange } = useForm<UploadBasicInputText>(
     { text: '' },
     { text: basicTextValidator }
   );
@@ -41,8 +41,7 @@ const useUploadTweet = () => {
 
   return {
     form: {
-      errors,
-      isError: { text: form.text && !errors.text.isValid && errors.text.message },
+      errorMessage: { text: getErrorMessage('text') },
       onChange,
       value: form,
     },

--- a/src/hooks/users/useEditProfile.ts
+++ b/src/hooks/users/useEditProfile.ts
@@ -20,7 +20,7 @@ const useEditProfile = () => {
     setIsEditedProfileSubmissionInProgress(false);
   };
 
-  const { errorMessage, errors, form, isError, onChange } = useForm<EditProfileInput>(
+  const { errorMessage, form, getErrorMessage, isError, onChange } = useForm<EditProfileInput>(
     {
       bio: profile?.profile?.bio || '',
       name: profile?.name || '',
@@ -67,8 +67,8 @@ const useEditProfile = () => {
     edit: { isEditProfile, onSubmit },
     form: {
       isError: {
-        bio: form.bio && !errors.bio.isValid && errors.bio.message,
-        name: form.name && !errors.name.isValid && errors.name.message,
+        bio: getErrorMessage('bio'),
+        name: getErrorMessage('name'),
       },
       onChange,
       values: form,

--- a/src/pages/log-in/index.tsx
+++ b/src/pages/log-in/index.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 
 export default function LogIn() {
   const {
-    form: { isError, onChange, values: form },
+    form: { errorMessage, onChange, values: form },
     login: { isLoginMutating, onSubmit },
   } = useLogIn();
 
@@ -16,7 +16,7 @@ export default function LogIn() {
         <form className="flex flex-col w-full gap-1 px-10" onSubmit={onSubmit}>
           <Input
             disabled={isLoginMutating}
-            errorMassage={isError.email}
+            errorMassage={errorMessage.email}
             name="email"
             onChange={onChange}
             placeholder="Your email"
@@ -26,7 +26,7 @@ export default function LogIn() {
           />
           <Input
             disabled={isLoginMutating}
-            errorMassage={isError.password}
+            errorMassage={errorMessage.password}
             name="password"
             onChange={onChange}
             placeholder="Your password"

--- a/src/pages/tweet/upload.tsx
+++ b/src/pages/tweet/upload.tsx
@@ -6,7 +6,7 @@ import { AiOutlinePicture } from 'react-icons/ai';
 
 export default function Upload() {
   const {
-    form: { isError, onChange, value },
+    form: { errorMessage, onChange, value },
     image: { cancelImage, previewImage, selectedImage },
     upload: { isCreatingTweet, onSubmit },
   } = useUploadTweet();
@@ -46,7 +46,7 @@ export default function Upload() {
         </button>
         <Textarea
           disabled={isCreatingTweet}
-          errorMassage={isError.text}
+          errorMassage={errorMessage.text}
           name="text"
           onChange={onChange}
           placeholder="텍스트를 입력해주세요."


### PR DESCRIPTION
# Feature
-  useForm 훅 변경

Closes #39 

# Description

불필요한 연산을 제거하고 변수값에 알맞은 식별자 네이밍으로 변경한다.

### 로직은 동일하지만 불필요한 연산을 제거 

- Obejct.entry와 forEach 메서드를 사용해 전체 데이터를 순회하는 방법이 아닌 직접 할당하는 방법으로 변경
- 에러메시지가 존재한다면 에러메시지를 노출해주는 getErrorMessage 함수를 생성하여 필요한 곳에 전체 교체

### 타입 수정
타입 인덱스 시그니처를 통해서 form 과 validator의 타입을 일치시키는 방향으로 변경

### 식별자 네이밍 변경
validate가 진행된 결과를 error로 명명되어있는 것이 값과 일치하지 못하므로 validatedResult로 식별자 네이밍 변경

# Additional
