### PR TITLE
Feature #51  트윗을 좋아요한 사용자 목록을 볼수 있는 기능 구현

### DIFF
--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -29,11 +29,11 @@ export default function Layout({
     <div className="container mx-auto">
       <header className="fixed z-10 flex items-center justify-between w-full max-w-xl px-10 border-b border-beige3 bg-base2 h-14">
         <div className="cursor-pointer" onClick={() => router.back()}>
-          <AiOutlineLeft
-            className={parameterToString(' stroke-beige1 fill-beige1', hasBackButton ? '' : 'hidden')}
-            size={25}
-            strokeWidth={40}
-          />
+          {hasBackButton ? (
+            <AiOutlineLeft className={parameterToString(' stroke-beige1 fill-beige1')} size={25} strokeWidth={40} />
+          ) : (
+            <div className="w-[25px]"></div>
+          )}
         </div>
         <div className="text-xl font-bold text-gray-800 cursor-pointer text-beige1 ">{title}</div>
         <div

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -35,7 +35,7 @@ export default function Layout({
             <div className="w-[25px]"></div>
           )}
         </div>
-        <div className="text-xl font-bold text-gray-800 cursor-pointer text-beige1 ">{title}</div>
+        <div className="text-xl font-bold text-gray-800 cursor-default text-beige1 ">{title}</div>
         <div
           onClick={() => {
             if (confirm('로그아웃 하시겠습니까?')) {

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,0 +1,29 @@
+import React, { PropsWithChildren } from 'react';
+import ReactDOM from 'react-dom';
+
+interface ModalProps {
+  children: React.ReactNode;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const Modal = ({ children, isOpen, onClose }: PropsWithChildren<ModalProps>) => {
+  const modalRoot = document.querySelector('#modal-root')!;
+  if (!isOpen) return null;
+
+  return ReactDOM.createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50" onClick={onClose}>
+      <div
+        onClick={(e: React.MouseEvent) => {
+          e.stopPropagation();
+        }}
+        className="px-6 bg-white rounded-lg shadow-lg"
+      >
+        {children}
+      </div>
+    </div>,
+    modalRoot
+  );
+};
+
+export default Modal;

--- a/src/components/common/TitleLogo.tsx
+++ b/src/components/common/TitleLogo.tsx
@@ -1,0 +1,10 @@
+import { ROUTE_PATH } from '@/constants';
+import useRouteToPath from '@/hooks/common/useRouteToPath';
+
+import Symbol from './Symbol';
+
+const TitleLogo = () => {
+  return <Symbol className="cursor-pointer" height={33} onClick={useRouteToPath(ROUTE_PATH.HOME)} width={33} />;
+};
+
+export default TitleLogo;

--- a/src/components/common/UserInformationItem.tsx
+++ b/src/components/common/UserInformationItem.tsx
@@ -5,17 +5,17 @@ import Link from 'next/link';
 
 import ProfileImage from '../images/ProfileImage';
 
-const UserInformation = ({ follow }: { follow: UserInformation }) => {
+const UserInformationItem = ({ user }: { user: UserInformation }) => {
   return (
     <Link
       className="flex items-center w-full gap-3 hover:scale-105 hover:translate-x-3 hover:ease-in-out hover:transition hover:duration-300"
-      href={`${ROUTE_PATH.PROFILE(follow.profile?.userId || '')}`}
-      key={follow.id}
+      href={`${ROUTE_PATH.PROFILE(user.profile?.userId || '')}`}
+      key={user.id}
     >
-      <ProfileImage alt={`${follow.name}_avatar`} avatarId={follow.profile?.avatar} size="md" />
-      <span className="font-bold">{follow.name}</span>
-      <small>{maskEmail(follow.email)}</small>
+      <ProfileImage alt={`${user.name}_avatar`} avatarId={user.profile?.avatar} size="md" />
+      <span className="font-bold">{user.name}</span>
+      <small>{maskEmail(user.email)}</small>
     </Link>
   );
 };
-export default UserInformation;
+export default UserInformationItem;

--- a/src/components/follows/follow/FollowersList.tsx
+++ b/src/components/follows/follow/FollowersList.tsx
@@ -1,11 +1,11 @@
-import UserInformation from '@/components/common/UserInformation';
+import UserInformation from '@/components/common/UserInformationItem';
 
 import useFollowContext from './useFollowContext';
 
 const FollowersList = () => {
   const follow = useFollowContext();
 
-  return <>{follow.followers?.map(follow => <UserInformation follow={follow.follower} key={follow.id} />)}</>;
+  return <>{follow.followers?.map(follow => <UserInformation key={follow.id} user={follow.follower} />)}</>;
 };
 
 export default FollowersList;

--- a/src/components/follows/follow/FollowingList.tsx
+++ b/src/components/follows/follow/FollowingList.tsx
@@ -1,11 +1,11 @@
-import UserInformation from '@/components/common/UserInformation';
+import UserInformationItem from '@/components/common/UserInformationItem';
 
 import useFollowContext from './useFollowContext';
 
 const FollowingList = () => {
   const follow = useFollowContext();
 
-  return <>{follow.following?.map(follow => <UserInformation follow={follow.following} key={follow.id} />)}</>;
+  return <>{follow.following?.map(follow => <UserInformationItem key={follow.id} user={follow.following} />)}</>;
 };
 
 export default FollowingList;

--- a/src/components/images/ProfileImage.tsx
+++ b/src/components/images/ProfileImage.tsx
@@ -5,7 +5,7 @@ import defaultProfileImage from '../../../public/default_profile.png';
 
 const styles = {
   size: {
-    lg: 'w-40 h-40',
+    lg: 'w-40 h-40 ',
     md: 'w-12 h-12',
     sm: 'w-8 h-8',
   },

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,6 +4,7 @@ export { default as LikeButton } from './common/LikeButton';
 export { default as LoadingSpinner } from './common/LoadingSpinner';
 export { default as Symbol } from './common/Symbol';
 export { default as Textarea } from './common/Textarea';
+export { default as TitleLogo } from './common/TitleLogo';
 
 export { default as ProfileImage } from './images/ProfileImage';
 export { default as TweetImage } from './images/TweetImage';

--- a/src/components/profiles/profile/DefaultProfileContent.tsx
+++ b/src/components/profiles/profile/DefaultProfileContent.tsx
@@ -10,7 +10,7 @@ const DefaultProfileContent = ({ children }: { children?: React.ReactNode }) => 
     count: 'w-full p-2 text-center text-brown2',
     hover:
       'hover:text-yellow3 hover:font-extrabold text-brown2 hover:scale-150 hover:text-yellow3 hover:ease-in-out hover:transition hover:duration-300',
-    link: 'flex flex-col items-center gap-3 rounded-sm aspect-square',
+    link: 'flex flex-col items-center sm:gap-3 rounded-sm aspect-square border-b border-base3',
   };
 
   return (
@@ -20,8 +20,8 @@ const DefaultProfileContent = ({ children }: { children?: React.ReactNode }) => 
         <h2 className="text-3xl font-bold">{profile.name}</h2>
         <small className="text-stone-500">{profile.email}</small>
       </div>
-      <div className="flex flex-col items-start self-start justify-center w-full gap-10 mt-14">
-        <div className="flex justify-center w-full gap-10 text-lg ">
+      <div className="flex flex-col items-center self-start justify-center w-full sm:gap-10 sm:mt-14">
+        <div className="flex flex-col justify-center gap-2 text-lg w-fit sm:w-full sm:gap-10 sm:flex-row ">
           <div className={styles.link}>
             <p>게시물</p>
             <p className={styles.count}>{profile.tweets.length}</p>

--- a/src/components/profiles/profile/DefaultProfileContent.tsx
+++ b/src/components/profiles/profile/DefaultProfileContent.tsx
@@ -21,7 +21,7 @@ const DefaultProfileContent = ({ children }: { children?: React.ReactNode }) => 
         <small className="text-stone-500">{profile.email}</small>
       </div>
       <div className="flex flex-col items-center self-start justify-center w-full sm:gap-10 sm:mt-14">
-        <div className="flex flex-col justify-center gap-2 text-lg w-fit sm:w-full sm:gap-10 sm:flex-row ">
+        <div className="flex flex-col justify-center gap-2 mb-1 text-lg w-fit sm:w-full sm:gap-10 sm:flex-row">
           <div className={styles.link}>
             <p>게시물</p>
             <p className={styles.count}>{profile.tweets.length}</p>

--- a/src/components/profiles/profile/index.tsx
+++ b/src/components/profiles/profile/index.tsx
@@ -17,7 +17,7 @@ export const ProfileRoot = ({
 }) => {
   return (
     <profileContext.Provider value={{ profile, refreshProfile }}>
-      <div className="flex flex-col justify-center gap-5">{children}</div>
+      <div className="flex flex-col justify-center gap-5 mt-2">{children}</div>
     </profileContext.Provider>
   );
 };

--- a/src/components/profiles/profile/index.tsx
+++ b/src/components/profiles/profile/index.tsx
@@ -17,7 +17,7 @@ export const ProfileRoot = ({
 }) => {
   return (
     <profileContext.Provider value={{ profile, refreshProfile }}>
-      <div className="flex flex-col justify-center gap-5 mt-10">{children}</div>
+      <div className="flex flex-col justify-center gap-5">{children}</div>
     </profileContext.Provider>
   );
 };

--- a/src/components/tweets/TweetDetailWithComments.tsx
+++ b/src/components/tweets/TweetDetailWithComments.tsx
@@ -10,7 +10,7 @@ const TweetDetailWithComments = () => {
     following: { onFollowing },
     like: { onToggleLike },
     loggedInUser,
-    tweet: { data, isDeleting, isLoading, onDelete },
+    tweet: { data, isDeleting, isLoading, onDelete, refreshTweet },
   } = useTweetViewModel();
 
   if (isLoading || !data || !loggedInUser) {
@@ -26,7 +26,7 @@ const TweetDetailWithComments = () => {
         <Tweet.Author onFollowing={onFollowing} />
         <Tweet.DeleteButton loggedInUserId={loggedInUser?.id} onDelete={onDelete} />
         <Tweet.Content />
-        <Tweet.Description onToggleLike={onToggleLike} />
+        <Tweet.Description modalOpenCallbackFn={refreshTweet} onToggleLike={onToggleLike} />
       </Tweet>
       <UploadCommentFrom />
       <CommentFeed loggedInUserId={loggedInUser.id} tweetComments={data.comments} />

--- a/src/components/tweets/TweetFeed.tsx
+++ b/src/components/tweets/TweetFeed.tsx
@@ -9,7 +9,7 @@ const TweetFeed = () => {
     following: { onFollowing },
     like: { onToggleLike },
     loggedInUser,
-    tweets: { bottomItemRef, isLoading, isValidating, responseTweets },
+    tweets: { bottomItemRef, isLoading, isValidating, refreshTweets, responseTweets },
   } = useInfiniteTweetsViewModel();
 
   if (isLoading || !responseTweets || !loggedInUser) {
@@ -21,7 +21,7 @@ const TweetFeed = () => {
         <Tweet key={tweet?.id} loggedInUserId={loggedInUser?.id} tweet={tweet}>
           <Tweet.Author onFollowing={onFollowing} />
           <Tweet.ContentWithLink />
-          <Tweet.Description onToggleLike={() => onToggleLike(tweet)} />
+          <Tweet.Description modalOpenCallbackFn={refreshTweets} onToggleLike={() => onToggleLike(tweet)} />
         </Tweet>
       ))}
       {isValidating ? <LoadingSpinner text={'불러오는 중..'} /> : <div ref={bottomItemRef}></div>}

--- a/src/components/tweets/TweetFeed.tsx
+++ b/src/components/tweets/TweetFeed.tsx
@@ -18,7 +18,7 @@ const TweetFeed = () => {
   return (
     <>
       {responseTweets.map((tweet: TweetResponse) => (
-        <Tweet key={tweet.id} loggedInUserId={loggedInUser?.id} tweet={tweet}>
+        <Tweet key={tweet?.id} loggedInUserId={loggedInUser?.id} tweet={tweet}>
           <Tweet.Author onFollowing={onFollowing} />
           <Tweet.ContentWithLink />
           <Tweet.Description onToggleLike={() => onToggleLike(tweet)} />

--- a/src/components/tweets/tweet/Author.tsx
+++ b/src/components/tweets/tweet/Author.tsx
@@ -13,7 +13,7 @@ import useTweetContext from './useTweetContext';
 export const Author = ({ onFollowing }: { onFollowing: (selectedTweet: TweetResponse) => void }) => {
   const { loggedInUserId, tweet } = useTweetContext();
   const router = useRouter();
-  const isAuthor = loggedInUserId === tweet.userId;
+  const isAuthor = loggedInUserId === tweet?.userId;
   const handleFollowing = () => {
     if (tweet) onFollowing(tweet);
   };

--- a/src/components/tweets/tweet/Content.tsx
+++ b/src/components/tweets/tweet/Content.tsx
@@ -8,7 +8,7 @@ export const ContentWithLink = () => {
   const { tweet } = useTweetContext();
 
   return (
-    <Link className="w-full" href={`${ROUTE_PATH.TWEETS}/${tweet?.id}`}>
+    <Link className="w-full" href={ROUTE_PATH.TWEET(tweet?.id)}>
       {tweet?.image && <TweetImage imageId={tweet.image} />}
       <p className="px-3 whitespace-pre-line">{tweet?.text}</p>
     </Link>

--- a/src/components/tweets/tweet/Description.tsx
+++ b/src/components/tweets/tweet/Description.tsx
@@ -8,17 +8,27 @@ import { useState } from 'react';
 import LikedUsersModal from './LikedUsersModal';
 import useTweetContext from './useTweetContext';
 
-export const Description = ({ onToggleLike }: { onToggleLike: (selectedTweet?: TweetResponse) => void }) => {
+export const Description = ({
+  modalOpenCallbackFn,
+  onToggleLike,
+}: {
+  modalOpenCallbackFn: () => void;
+  onToggleLike: (selectedTweet?: TweetResponse) => void;
+}) => {
   const { tweet } = useTweetContext();
 
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const handelLikedUserListModalOpen = () => {
+    modalOpenCallbackFn();
+    setIsModalOpen(true);
+  };
 
   return (
     <>
       <div className="flex items-center justify-between w-full gap-2">
         <div className="flex items-center gap-3 w-fit">
           <LikeButton isLiked={tweet?.isLiked} toggleLike={onToggleLike} />
-          <div className="cursor-pointer" onClick={() => setIsModalOpen(true)}>
+          <div className="cursor-pointer" onClick={handelLikedUserListModalOpen}>
             좋아요 <strong>{tweet?._count.likes}</strong> 개
           </div>
           <Link href={ROUTE_PATH.TWEET(tweet.id)}>

--- a/src/components/tweets/tweet/Description.tsx
+++ b/src/components/tweets/tweet/Description.tsx
@@ -1,6 +1,8 @@
 import LikeButton from '@/components/common/LikeButton';
+import { ROUTE_PATH } from '@/constants';
 import { formatDate } from '@/libs/client';
 import { TweetResponse } from '@/types';
+import Link from 'next/link';
 import { useState } from 'react';
 
 import LikedUsersModal from './LikedUsersModal';
@@ -19,9 +21,9 @@ export const Description = ({ onToggleLike }: { onToggleLike: (selectedTweet?: T
           <div className="cursor-pointer" onClick={() => setIsModalOpen(true)}>
             좋아요 <strong>{tweet?._count.likes}</strong> 개
           </div>
-          <div>
+          <Link href={ROUTE_PATH.TWEET(tweet.id)}>
             코멘트 <strong>{tweet?._count.comments}</strong> 개
-          </div>
+          </Link>
         </div>
         <small className="ml-auto text-stone-500">{formatDate(tweet?.createdAt)}</small>
       </div>

--- a/src/components/tweets/tweet/Description.tsx
+++ b/src/components/tweets/tweet/Description.tsx
@@ -1,23 +1,35 @@
 import LikeButton from '@/components/common/LikeButton';
 import { formatDate } from '@/libs/client';
 import { TweetResponse } from '@/types';
+import { useState } from 'react';
 
+import LikedUsersModal from './LikedUsersModal';
 import useTweetContext from './useTweetContext';
 
 export const Description = ({ onToggleLike }: { onToggleLike: (selectedTweet?: TweetResponse) => void }) => {
   const { tweet } = useTweetContext();
+
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
   return (
-    <div className="flex items-center justify-between w-full gap-2">
-      <div className="flex items-center gap-3 w-fit">
-        <LikeButton isLiked={tweet?.isLiked} toggleLike={onToggleLike} />
-        <span>
-          좋아요 <strong>{tweet?._count.likes}</strong> 개
-        </span>
-        <span>
-          코멘트 <strong>{tweet?._count.comments}</strong> 개
-        </span>
+    <>
+      <div className="flex items-center justify-between w-full gap-2">
+        <div className="flex items-center gap-3 w-fit">
+          <LikeButton isLiked={tweet?.isLiked} toggleLike={onToggleLike} />
+          <div className="cursor-pointer" onClick={() => setIsModalOpen(true)}>
+            좋아요 <strong>{tweet?._count.likes}</strong> 개
+          </div>
+          <div>
+            코멘트 <strong>{tweet?._count.comments}</strong> 개
+          </div>
+        </div>
+        <small className="ml-auto text-stone-500">{formatDate(tweet?.createdAt)}</small>
       </div>
-      <small className="ml-auto text-stone-500">{formatDate(tweet?.createdAt)}</small>
-    </div>
+      <LikedUsersModal
+        isOpen={isModalOpen}
+        likedUser={tweet.likes?.map(user => user.user) || []}
+        onClose={() => setIsModalOpen(false)}
+      />
+    </>
   );
 };

--- a/src/components/tweets/tweet/LikedUsersModal.tsx
+++ b/src/components/tweets/tweet/LikedUsersModal.tsx
@@ -1,0 +1,33 @@
+import type { UserInformation } from '@/types';
+
+import Button from '@/components/common/Button';
+import Modal from '@/components/common/Modal';
+import UserInformationItem from '@/components/common/UserInformationItem';
+
+const LikedUsersModal = ({
+  isOpen,
+  likedUser,
+  onClose,
+}: {
+  isOpen: boolean;
+  likedUser: UserInformation[];
+  onClose: () => void;
+}) => {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <div className="flex flex-col justify-between w-72 h-[500px] min-h-fit ">
+        <h3 className="mt-5 text-xl font-bold text-center text-base3">좋아요를 누른 사람들</h3>
+        <div className="flex flex-col h-[65%] gap-3 my-5 overflow-y-auto overflow-x-hidden">
+          {likedUser.map(user => (
+            <UserInformationItem key={user.id} user={user} />
+          ))}
+        </div>
+        <Button className="mb-3" onClick={onClose} size="sm">
+          닫기
+        </Button>
+      </div>
+    </Modal>
+  );
+};
+
+export default LikedUsersModal;

--- a/src/components/tweets/tweet/LikedUsersModal.tsx
+++ b/src/components/tweets/tweet/LikedUsersModal.tsx
@@ -16,7 +16,7 @@ const LikedUsersModal = ({
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <div className="flex flex-col justify-between w-72 h-[500px] min-h-fit ">
-        <h3 className="mt-5 text-xl font-bold text-center text-base3">좋아요를 누른 사람들</h3>
+        <h3 className="mt-5 text-xl font-bold text-center text-base3">좋아하는 사람</h3>
         <div className="flex flex-col h-[65%] gap-3 my-5 overflow-y-auto overflow-x-hidden">
           {likedUser.map(user => (
             <UserInformationItem key={user.id} user={user} />

--- a/src/constants/route.ts
+++ b/src/constants/route.ts
@@ -7,6 +7,7 @@ const ROUTE_PATH = {
   LOG_IN: '/log-in',
   MY_PROFILE: '/profile',
   PROFILE: (userId: string) => `/profile/${userId}`,
+  TWEET: (tweetId: string) => `/tweet/${tweetId}`,
   TWEETS: '/tweet',
   UPLOAD: '/upload',
 } as const;

--- a/src/hooks/common/useRouteToPath.ts
+++ b/src/hooks/common/useRouteToPath.ts
@@ -1,0 +1,8 @@
+import { useRouter } from 'next/router';
+
+const useRouteToPath = (routePath: string) => {
+  const router = useRouter();
+  return () => router.push(routePath);
+};
+
+export default useRouteToPath;

--- a/src/hooks/viewModel/useInfiniteTweetsViewModel.ts
+++ b/src/hooks/viewModel/useInfiniteTweetsViewModel.ts
@@ -65,7 +65,7 @@ const useInfiniteTweetsViewModel = () => {
     following: { onFollowing: optimisticFollowing },
     like: { onToggleLike: optimisticToggleLike },
     loggedInUser,
-    tweets: { bottomItemRef, isLoading, isValidating, responseTweets },
+    tweets: { bottomItemRef, isLoading, isValidating, refreshTweets: mutate, responseTweets },
   };
 };
 

--- a/src/hooks/viewModel/useTweetViewModel.ts
+++ b/src/hooks/viewModel/useTweetViewModel.ts
@@ -55,7 +55,7 @@ const useTweetViewModel = () => {
     following: { onFollowing: optimisticFollowing },
     like: { onToggleLike: optimisticToggleLike },
     loggedInUser,
-    tweet: { data: data?.data, isDeleting, isLoading, isValidating, onDelete },
+    tweet: { data: data?.data, isDeleting, isLoading, isValidating, onDelete, refreshTweet: mutate },
   };
 };
 

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -8,6 +8,7 @@ export default function Document() {
       <body>
         <Main />
         <NextScript />
+        <div id="modal-root"></div>
       </body>
     </Html>
   );

--- a/src/pages/api/tweets/[id]/index.ts
+++ b/src/pages/api/tweets/[id]/index.ts
@@ -33,6 +33,18 @@ async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType<Tw
           createdAt: 'asc',
         },
       },
+      likes: {
+        include: {
+          user: {
+            select: {
+              email: true,
+              id: true,
+              name: true,
+              profile: true,
+            },
+          },
+        },
+      },
       user: {
         select: {
           email: true,

--- a/src/pages/api/tweets/index.ts
+++ b/src/pages/api/tweets/index.ts
@@ -21,8 +21,15 @@ async function handler(req: NextApiRequest, res: NextApiResponse<ResponseType<Tw
         },
       },
       likes: {
-        where: {
-          userId: user?.id,
+        include: {
+          user: {
+            select: {
+              email: true,
+              id: true,
+              name: true,
+              profile: true,
+            },
+          },
         },
       },
       user: {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,10 @@
-import { Layout, Symbol } from '@/components';
+import { Layout, TitleLogo } from '@/components';
 import TweetsFeed from '@/components/tweets/TweetFeed';
+import { useRouter } from 'next/router';
 
 export default function Home() {
   return (
-    <Layout isLoggedIn title={<Symbol height={33} width={33} />}>
+    <Layout isLoggedIn title={<TitleLogo />}>
       <TweetsFeed />
     </Layout>
   );

--- a/src/pages/tweet/[id].tsx
+++ b/src/pages/tweet/[id].tsx
@@ -1,9 +1,9 @@
-import { Layout, Symbol } from '@/components';
+import { Layout, TitleLogo } from '@/components';
 import TweetDetailWithComments from '@/components/tweets/TweetDetailWithComments';
 
 export default function DetailTweet() {
   return (
-    <Layout hasBackButton isLoggedIn title={<Symbol height={33} width={33} />}>
+    <Layout hasBackButton isLoggedIn title={<TitleLogo />}>
       <TweetDetailWithComments />
     </Layout>
   );

--- a/src/pages/tweet/upload.tsx
+++ b/src/pages/tweet/upload.tsx
@@ -12,7 +12,7 @@ export default function Upload() {
   } = useUploadTweet();
 
   return (
-    <Layout hasBackButton isLoggedIn title="TWEET UPLOAD">
+    <Layout hasBackButton isLoggedIn title={'TWEET UPLOAD'}>
       <form className="flex flex-col items-center justify-center space-y-4 " onSubmit={onSubmit}>
         <label
           className="relative flex items-center justify-center w-full border-2 border-dashed rounded-lg cursor-pointer h-60 border-beige3"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -32,7 +32,7 @@ export interface TweetResponse extends Tweet {
   isFollowing?: boolean;
   isLiked?: boolean;
   likedTweetsByLoggedInUser?: boolean;
-  likes?: Like[];
+  likes?: (Like & { user: UserInformation })[];
   user: UserInformation;
 }
 


### PR DESCRIPTION
# Feature
 트윗을 좋아요한 사용자 목록을 볼수 있는 기능 구현

Closes #51 

# Description
하나의 글에서 좋아요 갯수를 누르면 좋아요한 사용자의 목록을 보여준다.
보여주는 형식은 라우팅하는 형식이 아닌, 모달을 사용하여 보여준다.


## 프론트엔드 

### 트윗리스트 또는 트윗상세에서 **좋아요 n개**를 클릭하면 `좋아하는 사람`리스트가 나열된 모달이 띄워진다.
- `좋아요하는 사람`리스트는 하나의 트윗에 종속되어있는 데이터로 보기때문에  **좋아요 n개**이 존재하는  Tweet.Description 에서 모달을 같이 띄우게한다.
    ```tsx
     // Tweet.Description
  return (
    <>
      <div className="flex items-center justify-between w-full gap-2">
           // ....
          <LikeButton isLiked={tweet?.isLiked} toggleLike={onToggleLike} />
          <div className="cursor-pointer" onClick={handelLikedUserListModalOpen}>
            좋아요 <strong>{tweet?._count.likes}</strong> 개
          </div>
          // ...Tweet.Description

      </div>
      <LikedUsersModal    // 좋아요한 사람 리스트 모달
        isOpen={isModalOpen}
        likedUser={tweet.likes?.map(user => user.user) || []}
        onClose={() => setIsModalOpen(false)}
      />
    </>
  );
    ```

|메이페이지(트윗리스트) | 트윗상세페이지|
|-|-|
|<img width="598" alt="image" src="https://github.com/j2h30728/dam-witter/assets/60846068/7ba3387f-ca2c-4a71-8acb-13f5c619aeed">| <img width="602" alt="image" src="https://github.com/j2h30728/dam-witter/assets/60846068/99cf4ad5-d0d9-46fa-afb9-da0f6d067a2f">|

- `좋아한 사람`리스트에서 사용자를 누르면 해당 사용자의 프로필 페이지로 이동된다.
- 모달은 닫기 버튼 또는 오버레이에 버튼을 누르면 닫힌다.
- 모달에서 `좋아한 사람`리스트의 공간보다 사람이 더 많아 질 경우에는 스크롤을 통해서 확인 할 수 있다.
    <img width="300" alt="image" src="https://github.com/j2h30728/dam-witter/assets/60846068/61905f3a-394c-4a09-ac62-ceb8a3024c55">


## 백엔드

기존의 tweets 와 tweet API에서 like에 user정보를 포함하여 반환한다.
```ts
      likes: {
        include: {
          user: {
            select: {
              email: true,
              id: true,
              name: true,
              profile: true,
            },
          },
        },
      },
```


# Additional

## 좋아요의 debounce VS 좋아한사람 리스트
트윗의 좋아요 버튼은 낙관적 업데이트와 400ms의 dbounce 으로 구현 되어있기 떄문에, 좋아요 버튼을 누르자마자 `좋아하는 사람 리스트` 모달을  띄우게되면 바로 적용되어있지 않은 형태이다.

현재 코드에는 `좋아하는 사람 리스트`모달을 띄우기전에 다시 mutate를 실행시켜 재검증을 통해 최대한 서버데이터와 동기를 맞추려했다.
하지만, 네트워크 지연보다는 debounce기능 때문에 동기가 빠르게 맞춰지지않기 명확하게 해결하지는 못했다.

추후에, 좋아요리스트를 정확하게 동기적으로 보여주기 위해서는 좋아요 버튼에서 debounce를 제거하거 경우도 고려해봐야할 것으로 보인다.