### PR TITLE
Feature #53 무한스크롤로 구현된 트윗리스트에 사용할 탑버튼 구현

### DIFF
--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -2,9 +2,12 @@ import { postFetcher } from '@/api/fetchers';
 import { ROUTE_PATH } from '@/constants';
 import { parameterToString } from '@/libs/client';
 import { useRouter } from 'next/router';
+import { useRef } from 'react';
 import { AiOutlineHome, AiOutlineLeft, AiOutlineLogout, AiOutlinePlusCircle, AiOutlineUser } from 'react-icons/ai';
 import { cache } from 'swr/_internal';
 import useSWRMutation from 'swr/mutation';
+
+import ScrollTopButton from './ScrollTopButton';
 
 export default function Layout({
   children,
@@ -24,6 +27,8 @@ export default function Layout({
       cache.delete('/api/users/profile');
     },
   });
+
+  const containerRef = useRef(null);
 
   return (
     <div className="container mx-auto">
@@ -55,7 +60,10 @@ export default function Layout({
           </div>
         </div>
       </header>
-      <div className="w-full h-screen px-2 pt-16 pb-32 overflow-auto border-solid overscroll-contain border-x-4 border-base">
+      <div
+        className="w-full h-screen px-2 pt-16 pb-32 overflow-auto border-solid overscroll-contain border-x-4 border-base"
+        ref={containerRef}
+      >
         {children}
       </div>
       {isLoggedIn ? (
@@ -85,6 +93,7 @@ export default function Layout({
           </nav>
         </footer>
       ) : null}
+      {!hasBackButton && isLoggedIn && <ScrollTopButton targetRef={containerRef} />}
     </div>
   );
 }

--- a/src/components/common/ScrollTopButton.tsx
+++ b/src/components/common/ScrollTopButton.tsx
@@ -1,0 +1,18 @@
+import { AiOutlineUp } from 'react-icons/ai';
+
+const ScrollTopButton = ({ targetRef }: { targetRef: React.RefObject<HTMLElement> }) => {
+  const scrollTolTop = () => {
+    targetRef.current?.scrollTo({ behavior: 'smooth', top: 0 });
+  };
+
+  return (
+    <div
+      className="absolute z-50 p-3 duration-200 ease-in rounded-full cursor-pointer right-5 bottom-20 bg-base2 hover:scale-110 hover:ease-out hover:transition hover:duration-300 active:scale-95"
+      onClick={scrollTolTop}
+    >
+      <AiOutlineUp className="stroke-2 stroke-beige1 fill-beige1" size={33} />
+    </div>
+  );
+};
+
+export default ScrollTopButton;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -16,7 +16,7 @@ export default function App({ Component, pageProps }: AppProps) {
         refreshInterval: 1000 * 60,
       }}
     >
-      <div className="w-full max-w-xl mx-auto bg-beige0">
+      <div className="relative w-full max-w-xl mx-auto bg-beige0">
         <Component {...pageProps} />
         <ToastContainer />
       </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,5 @@
 import { Layout, TitleLogo } from '@/components';
 import TweetsFeed from '@/components/tweets/TweetFeed';
-import { useRouter } from 'next/router';
 
 export default function Home() {
   return (


### PR DESCRIPTION
# Feature
- 무한스크롤로 구현된 트윗리스트에 사용할 탑버튼 구현

Closes #53 

# Description
현재 메인페이지에서 렌더되는 트윗리스트는 페이지 스크롤이 아닌, 레이아웃 컴포넌트 스크롤로 작동되고있다.
그러므로 useRef를 이용하여 레이아웃 컴포넌트 상단으로 스크롤 이동 시킨다.

### 지정된 화면을 넘어갈 경우 스크롤이 생성되는 레이아웃 컴포넌트의 상단으로 이동시키는 스크롤 탑 버튼 생성

```tsx
import { AiOutlineUp } from 'react-icons/ai';

const ScrollTopButton = ({ targetRef }: { targetRef: React.RefObject<HTMLElement> }) => {
  const scrollTolTop = () => {
    targetRef.current?.scrollTo({ behavior: 'smooth', top: 0 }); // 스크롤을 탑으로 이동시키고자하는 타겟 ref
  };

  return (
    <div
      className="absolute z-50 p-3 duration-200 ease-in rounded-full cursor-pointer right-5 bottom-20 bg-base2 hover:scale-110 hover:ease-out hover:transition hover:duration-300 active:scale-95"
      onClick={scrollTolTop}
    >
      <AiOutlineUp className="stroke-2 stroke-beige1 fill-beige1" size={33} />
    </div>
  );
};

export default ScrollTopButton;

```
위의 컴포넌트를 레이아웃 컴포넌트에 추가하여 메인페이지로 렌더할 경우 표시하게 끔 하였다.

https://github.com/j2h30728/dam-witter/assets/60846068/0306edd0-d79d-43fc-8702-7531b2083c81



# Additional

현재 탑버튼이 레이아웃에 포함되어있다. 메인페이지에서만 렌더해주기위해서 조건부 렌더식을 채택했다.
만약에 새로운 페이지나 상황에서 탑버튼이 필요할 경우에는 컴포넌트 분리가 필요하다.