### PR TITLE
Feature #60 에러 처리 보완하기

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "postcss": "8.4.26",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-error-boundary": "^4.0.12",
         "react-icons": "^4.10.1",
         "react-toastify": "^9.1.3",
         "swr": "^2.2.0",
@@ -5933,6 +5934,17 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.12.tgz",
+      "integrity": "sha512-kJdxdEYlb7CPC1A0SeUY38cHpjuu6UkvzKiAmqmOFL21VRfMhOcWxTCBgLVCO0VEMh9JhFNcVaXlV4/BTpiwOA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-icons": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "postcss": "8.4.26",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-error-boundary": "^4.0.12",
     "react-icons": "^4.10.1",
     "react-toastify": "^9.1.3",
     "swr": "^2.2.0",

--- a/src/api/fetchers.ts
+++ b/src/api/fetchers.ts
@@ -1,4 +1,5 @@
 import { METHOD } from '@/constants';
+import { DEFAULT_ERROR_MESSAGE } from '@/constants/api';
 import { ResponseType } from '@/types';
 
 export const getFetcher = async <F = unknown>(url: string): Promise<ResponseType<F>> => {
@@ -6,7 +7,8 @@ export const getFetcher = async <F = unknown>(url: string): Promise<ResponseType
     method: METHOD.GET,
   });
   if (!response.ok) {
-    throw (await response.json()).message;
+    const errorData = await response.json();
+    throw new Error(errorData.message || DEFAULT_ERROR_MESSAGE);
   }
   return response.json();
 };
@@ -16,7 +18,8 @@ export const postFetcher = async <T, F = unknown>(url: string, { arg }: { arg: T
     method: METHOD.POST,
   });
   if (!response.ok) {
-    throw (await response.json()).message;
+    const errorData = await response.json();
+    throw new Error(errorData.message || DEFAULT_ERROR_MESSAGE);
   }
   return response.json();
 };
@@ -26,7 +29,8 @@ export const deleteFetcher = async (url: string, { arg }: { arg?: string }): Pro
     method: METHOD.DELETE,
   });
   if (!response.ok) {
-    throw (await response.json()).message;
+    const errorData = await response.json();
+    throw new Error(errorData.message || DEFAULT_ERROR_MESSAGE);
   }
   return response.json();
 };
@@ -36,7 +40,8 @@ export const putFetcher = async <T, F = unknown>(url: string, { arg }: { arg: T 
     method: METHOD.PUT,
   });
   if (!response.ok) {
-    throw (await response.json()).message;
+    const errorData = await response.json();
+    throw new Error(errorData.message || DEFAULT_ERROR_MESSAGE);
   }
   return response.json();
 };

--- a/src/api/followingFetcher.ts
+++ b/src/api/followingFetcher.ts
@@ -1,4 +1,4 @@
-import { END_POINTS } from '@/constants/api';
+import { DEFAULT_ERROR_MESSAGE, END_POINTS } from '@/constants/api';
 import { METHOD_TYPE } from '@/constants/method';
 import { ResponseType } from '@/types';
 import { Profile } from '@prisma/client';
@@ -11,7 +11,8 @@ export const followingFetcher = async (
     method: arg.method,
   });
   if (!response.ok) {
-    throw (await response.json()).message;
+    const errorData = await response.json();
+    throw new Error(errorData.message || DEFAULT_ERROR_MESSAGE);
   }
   return response.json();
 };

--- a/src/components/common/DefaultErrorBoundary.tsx
+++ b/src/components/common/DefaultErrorBoundary.tsx
@@ -1,0 +1,38 @@
+import { ROUTE_PATH } from '@/constants';
+import { useRouter } from 'next/router';
+
+import Button from './Button';
+import Layout from './Layout';
+
+interface ErrorBoundaryProps {
+  error: Error;
+  resetErrorBoundary: () => void;
+}
+
+const DefaultErrorBoundary = ({ error, resetErrorBoundary }: ErrorBoundaryProps) => {
+  const router = useRouter();
+  return (
+    <Layout title={<h1>ERROR</h1>}>
+      <div className="flex flex-col items-center justify-center w-full h-full space-y-8">
+        <h2 className="text-3xl font-extrabold">오류가 발생했습니다!</h2>
+        <span className="text-xl font-semibold">아래의 버튼을 사용해주세요.</span>
+        <span className="font-semibold text-md text-slate-600">{error.message}</span>
+        <div className="flex gap-3">
+          <Button
+            onClick={() => {
+              resetErrorBoundary();
+              router.replace(ROUTE_PATH.HOME);
+            }}
+          >
+            홈으로 이동
+          </Button>
+          <Button onClick={() => resetErrorBoundary()} size="md" type="button">
+            다시 시도하기
+          </Button>
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export default DefaultErrorBoundary;

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -31,7 +31,7 @@ export default function Layout({
   const containerRef = useRef(null);
 
   return (
-    <div className="container mx-auto">
+    <div className="container relative w-full max-w-xl mx-auto bg-beige0">
       <header className="fixed z-10 flex items-center justify-between w-full max-w-xl px-10 border-b border-beige3 bg-base2 h-14">
         <div className="cursor-pointer" onClick={() => router.back()}>
           {hasBackButton ? (

--- a/src/hooks/api/useInfiniteScrollData.ts
+++ b/src/hooks/api/useInfiniteScrollData.ts
@@ -2,7 +2,7 @@ import { PAGE_SIZE } from '@/constants/api';
 import { ResponseType } from '@/types';
 import useSWRInfinite from 'swr/infinite';
 
-import useIntersectionObserver from './useIntersectionObserver';
+import useIntersectionObserver from '../common/useIntersectionObserver';
 
 const getKey = <T>(index: number, previousPageData: T[] | null, url: string) => {
   if (previousPageData && previousPageData.length === 0) return null;

--- a/src/hooks/tweets/useInfiniteTweets.ts
+++ b/src/hooks/tweets/useInfiniteTweets.ts
@@ -1,5 +1,5 @@
 import { END_POINTS } from '@/constants/api';
-import useGetInfiniteData from '@/hooks/common/useInfiniteScrollData';
+import useGetInfiniteData from '@/hooks/api/useInfiniteScrollData';
 import { TweetResponse } from '@/types';
 
 const useInfiniteTweets = () => {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,7 +1,10 @@
 import type { AppProps } from 'next/app';
 
+import { getFetcher } from '@/api/fetchers';
+import DefaultErrorBoundary from '@/components/common/DefaultErrorBoundary';
 import { toastMessage } from '@/libs/client/toastMessage';
 import '@/styles/globals.css';
+import { ErrorBoundary } from 'react-error-boundary';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import { SWRConfig } from 'swr';
@@ -10,16 +13,16 @@ export default function App({ Component, pageProps }: AppProps) {
   return (
     <SWRConfig
       value={{
-        fetcher: (url: string) => fetch(url).then(response => response.json()),
+        fetcher: getFetcher,
         onError: (error: string) => toastMessage('error', error),
-
         refreshInterval: 1000 * 60,
+        shouldRetryOnError: false,
       }}
     >
-      <div className="relative w-full max-w-xl mx-auto bg-beige0">
+      <ErrorBoundary FallbackComponent={DefaultErrorBoundary}>
         <Component {...pageProps} />
         <ToastContainer />
-      </div>
+      </ErrorBoundary>
     </SWRConfig>
   );
 }

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -1,0 +1,32 @@
+import { Layout } from '@/components';
+import Button from '@/components/common/Button';
+import { ROUTE_PATH } from '@/constants';
+import { NextPageContext } from 'next';
+import { useRouter } from 'next/router';
+
+function Error({ statusCode }: { statusCode: number }) {
+  const router = useRouter();
+  return (
+    <Layout title={<h1>ERROR</h1>}>
+      <div className="flex flex-col items-center justify-center w-full h-full space-y-8">
+        <h2 className="text-3xl font-extrabold">{statusCode} : 오류가 발생했습니다!</h2>
+        <div className="flex gap-3">
+          <Button
+            onClick={() => {
+              router.replace(ROUTE_PATH.HOME);
+            }}
+          >
+            홈으로 이동
+          </Button>
+        </div>
+      </div>
+    </Layout>
+  );
+}
+
+Error.getInitialProps = ({ err, res }: NextPageContext) => {
+  const statusCode = res ? res.statusCode : err ? err.statusCode : 404;
+  return { statusCode };
+};
+
+export default Error;


### PR DESCRIPTION
# Feature

- 에러 처리 보완하기

Closes #60 

# Description
현재 api 단에서 일어날 수 있는 에러를 분기처리해서 내려주지만, 클라이언트 단에서 세부적으로 보완할 곳이 보여 진행한다.

### 클라이언트 단에서의  에러 처리

|종류 | 내용
|-|-|
|_error.tsx 추가| 라우팅 에러 처리|
|에러 바운더리 추가| 리액트 컴포넌트의 라이프사이클 동안 발생하는 동기적 에러를 처리. 컴포넌트가 렌더링하는 동안 발생하는 예외 상황을 처리|
|SWR의 onError 콜백|useSWR이나 useSWRMutation 훅에서 API 통신 중 발생하는 에러를 처리로 토스트메시지로 에러 알람, fetcher 함수에서 Error 를 throw 함|
|기타 | 각각의 로직, 해당 컴포넌트 내에서 에러토스트메시지 알람 등 각각 처리 |

내용

# Additional

현재 레이아웃 컴포넌트가 복잡해서 각각의 페이지 라우트의 상단에서 에러바운더리가 동작하게끔 _app.tsx 파일에 씌웠다.
추후에 레이아웃 컴포넌트가 리팩토링이 되고 프로젝트가 복잡해지면  더 세부적으로 변경할 수 있다.