### PR TITLE
Feature #65 특정 사용자가 작성한 트윗만을 확인하는 트윗피드 생성 

### DIFF
--- a/src/components/comments/CommentFeed.tsx
+++ b/src/components/comments/CommentFeed.tsx
@@ -13,7 +13,7 @@ const CommentFeed = ({
   const { onDelete } = useCommentViewModel();
 
   return (
-    <div className="flex flex-col gap-3">
+    <div className="flex flex-col gap-3 px-2">
       {tweetComments?.map(comment => (
         <CommentItem comment={comment} key={comment.id} loggedInUserId={loggedInUserId} onRemove={onDelete} />
       ))}

--- a/src/components/common/DefaultErrorBoundary.tsx
+++ b/src/components/common/DefaultErrorBoundary.tsx
@@ -2,7 +2,7 @@ import { ROUTE_PATH } from '@/constants';
 import { useRouter } from 'next/router';
 
 import Button from './Button';
-import Layout from './Layout';
+import Layout from './layout/Layout';
 
 interface ErrorBoundaryProps {
   error: Error;

--- a/src/components/common/ScrollTopButton.tsx
+++ b/src/components/common/ScrollTopButton.tsx
@@ -3,7 +3,7 @@ import { AiOutlineUp } from 'react-icons/ai';
 const ScrollTopButton = ({ onClick }: { onClick: () => void }) => {
   return (
     <div
-      className="absolute z-50 p-3 duration-200 ease-in rounded-full cursor-pointer right-5 bottom-20 bg-base2 hover:scale-110 hover:ease-out hover:transition hover:duration-300 active:scale-95"
+      className="absolute z-50 p-3 duration-200 ease-in rounded-full cursor-pointer right-5 bottom-7 bg-base2 hover:scale-110 hover:ease-out hover:transition hover:duration-300 active:scale-95"
       onClick={onClick}
     >
       <AiOutlineUp className="stroke-2 stroke-beige1 fill-beige1" size={33} />

--- a/src/components/common/layout/Layout.tsx
+++ b/src/components/common/layout/Layout.tsx
@@ -55,9 +55,7 @@ export default function Layout({
           </div>
         </div>
       </header>
-      <div className="h-[calc(100vh-7.5em)] mt-14 pt-2 pb-2 first-letter:overflow-x-hidden overflow-y-auto">
-        {children}
-      </div>
+      <div className="h-[calc(100vh-7.5rem)] pt-2 mt-14 first-letter:overflow-x-hidden overflow-y-auto">{children}</div>
       {isLoggedIn ? (
         <nav className="fixed bottom-0 z-10 flex items-center justify-between w-full h-16 max-w-xl px-10 text-xs text-gray-700 border-t border-beige3 bg-base2">
           <div

--- a/src/components/common/layout/Layout.tsx
+++ b/src/components/common/layout/Layout.tsx
@@ -26,7 +26,7 @@ export default function Layout({
   });
 
   return (
-    <div className="container relative w-full h-screen max-w-xl mx-auto border-solid bg-beige0 border-x-4 border-base">
+    <div className="container relative w-full max-w-xl mx-auto border-solid bg-beige0 border-x-4 border-base">
       <header className="fixed top-0 z-10 flex items-center justify-between w-full max-w-xl px-10 border-b border-beige3 bg-base2 h-14">
         <div className="cursor-pointer" onClick={() => router.back()}>
           {hasBackButton ? (
@@ -55,7 +55,9 @@ export default function Layout({
           </div>
         </div>
       </header>
-      <div className="pt-16">{children}</div>
+      <div className="h-[calc(100vh-7.5em)] mt-14 pt-2 pb-2 first-letter:overflow-x-hidden overflow-y-auto">
+        {children}
+      </div>
       {isLoggedIn ? (
         <nav className="fixed bottom-0 z-10 flex items-center justify-between w-full h-16 max-w-xl px-10 text-xs text-gray-700 border-t border-beige3 bg-base2">
           <div

--- a/src/components/common/layout/NestedLayout.tsx
+++ b/src/components/common/layout/NestedLayout.tsx
@@ -1,5 +1,4 @@
 import { parameterToString } from '@/libs/client';
-import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { forwardRef, useImperativeHandle, useRef } from 'react';
 
@@ -9,7 +8,7 @@ export interface NestedLayoutHandle {
   scrollToTop: () => void;
 }
 
-const NestedLayout = forwardRef<NestedLayoutHandle, React.PropsWithChildren<{ navigation: Navigation[] }>>(
+const NestedLayout = forwardRef<NestedLayoutHandle, React.PropsWithChildren<{ navigation?: Navigation[] }>>(
   ({ children, navigation }, ref) => {
     const router = useRouter();
     const containerRef = useRef<HTMLDivElement>(null);
@@ -32,7 +31,7 @@ const NestedLayout = forwardRef<NestedLayoutHandle, React.PropsWithChildren<{ na
     return (
       <>
         <nav className="fixed z-10 flex justify-around w-full max-w-xl pt-3 text-lg text-center top-14 bg-beige0 ">
-          {navigation.map(nav => (
+          {navigation?.map(nav => (
             <div
               className={parameterToString(
                 nav.isCurrentPath ? 'font-bold text-orange-800' : 'text-stone-400',

--- a/src/components/common/layout/NestedLayout.tsx
+++ b/src/components/common/layout/NestedLayout.tsx
@@ -1,6 +1,9 @@
 import { parameterToString } from '@/libs/client';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { forwardRef, useImperativeHandle, useRef } from 'react';
+import { forwardRef, useEffect, useImperativeHandle, useLayoutEffect, useRef } from 'react';
+
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
 export type Navigation = { href: string; isCurrentPath: boolean; title: string };
 
@@ -23,29 +26,37 @@ const NestedLayout = forwardRef<NestedLayoutHandle, React.PropsWithChildren<{ na
       []
     );
 
-    const handleNavigation = async (href: string) => {
-      await router.push(href);
-      if (containerRef.current) containerRef.current.scrollTop = 0;
-    };
+    useIsomorphicLayoutEffect(() => {
+      const currentRef = containerRef.current;
+      return () => {
+        if (currentRef) currentRef.scrollTop = 0;
+      };
+    }, [router.query]);
 
     return (
       <>
         <nav className="fixed z-10 flex justify-around w-full max-w-xl pt-3 text-lg text-center top-14 bg-beige0 ">
           {navigation?.map(nav => (
-            <div
+            <Link
               className={parameterToString(
                 nav.isCurrentPath ? 'font-bold text-orange-800' : 'text-stone-400',
                 'border-b-2 w-full',
                 'cursor-pointer'
               )}
+              href={nav.href}
               key={nav.title}
-              onClick={() => handleNavigation(nav.href)}
             >
               {nav.title}
-            </div>
+            </Link>
           ))}
         </nav>
-        <div className=" h-[calc(100vh-8rem)] pt-10 px-2 overflow-y-auto overflow-x-hidden" ref={containerRef}>
+        <div
+          className={parameterToString(
+            'h-[calc(100vh-8rem)] px-2 overflow-y-auto overflow-x-hidden',
+            navigation?.length ? '  pt-10' : ''
+          )}
+          ref={containerRef}
+        >
           {children}
         </div>
       </>

--- a/src/components/common/loader/Loader.tsx
+++ b/src/components/common/loader/Loader.tsx
@@ -1,0 +1,11 @@
+import LoadingSpinner from './LoadingSpinner';
+
+const Loader = ({ loaderText }: { loaderText: string }) => {
+  return (
+    <div className="flex items-center justify-center h-[calc(100vh-8rem)]">
+      <LoadingSpinner text={loaderText} />
+    </div>
+  );
+};
+
+export default Loader;

--- a/src/components/common/loader/LoadingSpinner.tsx
+++ b/src/components/common/loader/LoadingSpinner.tsx
@@ -1,6 +1,6 @@
 export default function LoadingSpinner({ text }: { text?: String }) {
   return (
-    <div className="flex flex-col items-center justify-center w-full h-full gap-5 mt-5">
+    <div className="flex flex-col items-center justify-center w-full gap-5 my-10 h-fit ">
       <div className="w-16 h-16 border-t-4 border-b-4 border-gray-900 rounded-full animate-spin"></div>
       <span>{text}</span>
     </div>

--- a/src/components/follows/FollowLayout.tsx
+++ b/src/components/follows/FollowLayout.tsx
@@ -3,8 +3,8 @@ import useFollow from '@/hooks/api/useFollow';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 
-import Layout from '../common/Layout';
-import NestedLayout, { Navigation } from '../common/NestedLayout';
+import Layout from '../common/layout/Layout';
+import NestedLayout, { Navigation } from '../common/layout/NestedLayout';
 
 const FollowLayout = ({ children }: React.PropsWithChildren<{}>) => {
   const { pathname, query } = useRouter();

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,10 +1,10 @@
 export { default as Input } from './common/Input';
-export { default as Layout } from './common/Layout';
 export { default as LikeButton } from './common/LikeButton';
 export { default as LoadingSpinner } from './common/LoadingSpinner';
 export { default as Symbol } from './common/Symbol';
 export { default as Textarea } from './common/Textarea';
 export { default as TitleLogo } from './common/TitleLogo';
+export { default as Layout } from './common/layout/Layout';
 
 export { default as ProfileImage } from './images/ProfileImage';
 export { default as TweetImage } from './images/TweetImage';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,10 +1,11 @@
 export { default as Input } from './common/Input';
 export { default as LikeButton } from './common/LikeButton';
-export { default as LoadingSpinner } from './common/LoadingSpinner';
 export { default as Symbol } from './common/Symbol';
 export { default as Textarea } from './common/Textarea';
 export { default as TitleLogo } from './common/TitleLogo';
 export { default as Layout } from './common/layout/Layout';
+export { default as Loader } from './common/loader/Loader';
+export { default as LoadingSpinner } from './common/loader/LoadingSpinner';
 
 export { default as ProfileImage } from './images/ProfileImage';
 export { default as TweetImage } from './images/TweetImage';

--- a/src/components/profiles/DefaultUserProfile.tsx
+++ b/src/components/profiles/DefaultUserProfile.tsx
@@ -1,13 +1,13 @@
+import { Loader } from '@/components';
 import useProfile from '@/hooks/api/useProfile';
 
-import LoadingSpinner from '../common/LoadingSpinner';
 import { Profile } from './profile';
 
 const DefaultUserProfile = () => {
   const { isLoading, profile, refreshProfile } = useProfile();
 
   if (!profile || isLoading) {
-    return <LoadingSpinner text={'불러오는 중..'} />;
+    return <Loader loaderText="불러오는 중.." />;
   }
 
   return (

--- a/src/components/profiles/MyProfile.tsx
+++ b/src/components/profiles/MyProfile.tsx
@@ -1,13 +1,13 @@
+import { Loader } from '@/components';
 import useMyProfile from '@/hooks/api/useMyProfile';
 
-import LoadingSpinner from '../common/LoadingSpinner';
 import { Profile } from './profile';
 
 const MyProfile = () => {
   const { isLoading, profile } = useMyProfile();
 
   if (!profile || isLoading) {
-    return <LoadingSpinner text={'불러오는 중..'} />;
+    return <Loader loaderText="불러오는 중.." />;
   }
 
   return (

--- a/src/components/profiles/profile/DefaultProfileContent.tsx
+++ b/src/components/profiles/profile/DefaultProfileContent.tsx
@@ -7,14 +7,13 @@ import useProfileContext from './useProfileContext';
 const DefaultProfileContent = ({ children }: { children?: React.ReactNode }) => {
   const { profile } = useProfileContext();
   const styles = {
-    count: 'w-full p-2 text-center text-brown2',
-    hover:
-      'hover:text-yellow3 hover:font-extrabold text-brown2 hover:scale-150 hover:text-yellow3 hover:ease-in-out hover:transition hover:duration-300',
+    count:
+      'w-full p-2 text-center text-brown2 hover:text-yellow3 hover:font-extrabold text-brown2 hover:scale-150 hover:text-yellow3 hover:ease-in-out hover:transition hover:duration-300',
     link: 'flex flex-col items-center sm:gap-3 rounded-sm aspect-square border-b border-base3',
   };
 
   return (
-    <div className="flex w-full">
+    <div className="flex w-full h-full">
       <div className="flex flex-col items-center w-full gap-1 px-2">
         <ProfileImage alt="avatar" avatarId={profile.profile?.avatar} size="lg" />
         <h2 className="text-3xl font-bold">{profile.name}</h2>
@@ -22,17 +21,17 @@ const DefaultProfileContent = ({ children }: { children?: React.ReactNode }) => 
       </div>
       <div className="flex flex-col items-center self-start justify-center w-full sm:gap-10 sm:mt-14">
         <div className="flex flex-col justify-center gap-2 mb-1 text-lg w-fit sm:w-full sm:gap-10 sm:flex-row">
-          <div className={styles.link}>
+          <Link className={styles.link} href={ROUTE_PATH.USER_TWEETS(profile.profile?.userId || '')}>
             <p>게시물</p>
             <p className={styles.count}>{profile.tweets.length}</p>
-          </div>
+          </Link>
           <Link className={styles.link} href={ROUTE_PATH.FOLLOWERS(profile.profile?.userId || '')}>
             <p>팔로워</p>
-            <p className={styles.count + styles.hover}>{profile.followers.length}</p>
+            <p className={styles.count}>{profile.followers.length}</p>
           </Link>
           <Link className={styles.link} href={ROUTE_PATH.FOLLOWING(profile.profile?.userId || '')}>
             <p>팔로잉</p>
-            <p className={styles.count + styles.hover}>{profile.following.length}</p>
+            <p className={styles.count}>{profile.following.length}</p>
           </Link>
         </div>
         {children}

--- a/src/components/profiles/profile/index.tsx
+++ b/src/components/profiles/profile/index.tsx
@@ -17,7 +17,7 @@ export const ProfileRoot = ({
 }) => {
   return (
     <profileContext.Provider value={{ profile, refreshProfile }}>
-      <div className="flex flex-col h-full gap-5 px-2 mt-2">{children}</div>
+      <div className="flex flex-col justify-around gap-5 px-2 h-fit">{children}</div>
     </profileContext.Provider>
   );
 };

--- a/src/components/tweets/TweetDetailWithComments.tsx
+++ b/src/components/tweets/TweetDetailWithComments.tsx
@@ -1,8 +1,8 @@
+import { Loader } from '@/components';
 import useTweetViewModel from '@/hooks/viewModel/useTweetViewModel';
 
 import CommentFeed from '../comments/CommentFeed';
 import UploadCommentFrom from '../comments/UploadCommentFrom';
-import LoadingSpinner from '../common/LoadingSpinner';
 import { Tweet } from './tweet';
 
 const TweetDetailWithComments = () => {
@@ -14,10 +14,10 @@ const TweetDetailWithComments = () => {
   } = useTweetViewModel();
 
   if (isLoading || !data || !loggedInUser) {
-    return <LoadingSpinner text={'불러오는 중..'} />;
+    return <Loader loaderText="불러오는 중.." />;
   }
   if (isDeleting) {
-    return <LoadingSpinner text="트윗 삭제 중 입니다." />;
+    return <Loader loaderText="트윗 삭제 중 입니다." />;
   }
 
   return (

--- a/src/components/tweets/TweetFeed.tsx
+++ b/src/components/tweets/TweetFeed.tsx
@@ -1,7 +1,7 @@
 import useInfiniteTweetsViewModel, { TweetsFeedEndpoint } from '@/hooks/viewModel/useInfiniteTweetsViewModel';
 import { TweetResponse } from '@/types';
 
-import LoadingSpinner from '../common/LoadingSpinner';
+import LoadingSpinner from '../common/loader/LoadingSpinner';
 import { Tweet } from './tweet';
 
 const TweetFeed = ({ endpoint }: TweetsFeedEndpoint) => {

--- a/src/components/tweets/TweetFeed.tsx
+++ b/src/components/tweets/TweetFeed.tsx
@@ -1,19 +1,20 @@
 import useInfiniteTweetsViewModel, { TweetsFeedEndpoint } from '@/hooks/viewModel/useInfiniteTweetsViewModel';
 import { TweetResponse } from '@/types';
 
+import Loader from '../common/loader/Loader';
 import LoadingSpinner from '../common/loader/LoadingSpinner';
 import { Tweet } from './tweet';
 
-const TweetFeed = ({ endpoint }: TweetsFeedEndpoint) => {
+const TweetFeed = ({ endpoint, query }: TweetsFeedEndpoint) => {
   const {
     following: { onFollowing },
     like: { onToggleLike },
     loggedInUser,
     tweets: { bottomItemRef, isLoading, isValidating, refreshTweets, responseTweets },
-  } = useInfiniteTweetsViewModel({ endpoint });
+  } = useInfiniteTweetsViewModel({ endpoint, query });
 
   if (isLoading || !responseTweets || !loggedInUser) {
-    return <LoadingSpinner text={'불러오는 중..'} />;
+    return <Loader loaderText={'불러오는 중..'} />;
   }
 
   return (
@@ -25,9 +26,7 @@ const TweetFeed = ({ endpoint }: TweetsFeedEndpoint) => {
           <Tweet.Description modalOpenCallbackFn={refreshTweets} onToggleLike={() => onToggleLike(tweet)} />
         </Tweet>
       ))}
-      <div className="h-52">
-        {isValidating ? <LoadingSpinner text={'불러오는 중..'} /> : <div ref={bottomItemRef}></div>}
-      </div>
+      {isValidating ? <LoadingSpinner text={'불러오는 중..'} /> : <div ref={bottomItemRef}></div>}
     </>
   );
 };

--- a/src/components/tweets/TweetFeedLayout.tsx
+++ b/src/components/tweets/TweetFeedLayout.tsx
@@ -1,26 +1,10 @@
-import { ROUTE_PATH } from '@/constants';
-import { useRouter } from 'next/router';
 import { useRef } from 'react';
 
-import NestedLayout, { Navigation, NestedLayoutHandle } from '../common/NestedLayout';
 import ScrollTopButton from '../common/ScrollTopButton';
+import NestedLayout, { Navigation, NestedLayoutHandle } from '../common/layout/NestedLayout';
 
-const TweetFeedLayout = ({ children }: { children: React.ReactNode }) => {
-  const { pathname } = useRouter();
+const TweetFeedLayout = ({ children, navigation }: { children: React.ReactNode; navigation?: Navigation[] }) => {
   const nestedLayoutRef = useRef<NestedLayoutHandle>(null);
-
-  const tweetHeader: Navigation[] = [
-    {
-      href: ROUTE_PATH.HOME,
-      isCurrentPath: pathname === ROUTE_PATH.HOME,
-      title: '전체 보기',
-    },
-    {
-      href: ROUTE_PATH.FOLLOWING_TWEETS,
-      isCurrentPath: pathname.includes('following'),
-      title: '팔로잉',
-    },
-  ];
 
   const handleScrollToTop = () => {
     nestedLayoutRef.current?.scrollToTop();
@@ -28,7 +12,7 @@ const TweetFeedLayout = ({ children }: { children: React.ReactNode }) => {
 
   return (
     <>
-      <NestedLayout navigation={tweetHeader} ref={nestedLayoutRef}>
+      <NestedLayout navigation={navigation} ref={nestedLayoutRef}>
         {children}
       </NestedLayout>
       <ScrollTopButton onClick={handleScrollToTop} />

--- a/src/constants/route.ts
+++ b/src/constants/route.ts
@@ -11,6 +11,7 @@ const ROUTE_PATH = {
   TWEET: (tweetId: string) => `/tweet/${tweetId}`,
   TWEETS: '/tweet',
   UPLOAD: '/upload',
+  USER_TWEETS: (userId: string) => `/profile/${userId}/tweets`,
 } as const;
 
 export default ROUTE_PATH;

--- a/src/hooks/api/useInfiniteScrollData.ts
+++ b/src/hooks/api/useInfiniteScrollData.ts
@@ -4,15 +4,24 @@ import useSWRInfinite from 'swr/infinite';
 
 import useIntersectionObserver from '../common/useIntersectionObserver';
 
-const getKey = <T>(index: number, previousPageData: T[] | null, url: string) => {
-  if (previousPageData && previousPageData.length === 0) return null;
-  if (index === 0) return url;
-  return `${url}?pageIndex=${index}&limit=${PAGE_SIZE}`;
+type GetKey = (
+  index: number,
+  previousPageData: ResponseType<any>[] | null,
+  url: string,
+  query?: string
+) => null | string;
+
+const getKey: GetKey = (index, previousPageData, url, query) => {
+  if (index === 0) return `${url}?pageIndex=${index}&limit=${PAGE_SIZE}&${query}`;
+  if (!previousPageData || previousPageData.length === 0 || previousPageData.at(-1)?.data.length < PAGE_SIZE) {
+    return null;
+  }
+  return `${url}?pageIndex=${index}&limit=${PAGE_SIZE}&${query}`;
 };
 
-const useInfiniteScrollData = <T>(url: string) => {
+const useInfiniteScrollData = <T>({ query, url }: { query?: string; url: string }) => {
   const { data, isLoading, isValidating, mutate, setSize } = useSWRInfinite<ResponseType<T[]>[]>((...args) =>
-    getKey(...args, url)
+    getKey(...args, url, query)
   );
   const flattedData = data?.flat() ?? [];
 

--- a/src/hooks/viewModel/useInfiniteTweetsViewModel.ts
+++ b/src/hooks/viewModel/useInfiniteTweetsViewModel.ts
@@ -7,15 +7,17 @@ import useMyProfile from '../api/useMyProfile';
 import useLike from '../tweets/useLike';
 export interface TweetsFeedEndpoint {
   endpoint: string;
+  query?: string;
 }
-const useInfiniteTweetsViewModel = ({ endpoint }: TweetsFeedEndpoint) => {
+const useInfiniteTweetsViewModel = ({ endpoint, query }: TweetsFeedEndpoint) => {
   const {
     bottomItemRef,
     data: originTweets,
     isLoading,
     isValidating,
     mutate,
-  } = useGetInfiniteData<TweetResponse>(endpoint);
+  } = useGetInfiniteData<TweetResponse>({ query, url: endpoint });
+
   const responseTweets = originTweets.flatMap(tweet => tweet.data) as TweetResponse[];
 
   const { profile: loggedInUser } = useMyProfile();

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import { Layout, TitleLogo } from '@/components';
 import TweetsFeed from '@/components/tweets/TweetFeed';
 import TweetFeedLayout from '@/components/tweets/TweetFeedLayout';
+import { ROUTE_PATH } from '@/constants';
 import { END_POINTS } from '@/constants/api';
 
 import { NextPageWithLayout } from './_app';
@@ -10,9 +11,22 @@ const Home: NextPageWithLayout = () => {
 };
 
 Home.getLayout = function getLayout(page: React.ReactElement) {
+  const navigationConfig = [
+    {
+      href: ROUTE_PATH.HOME,
+      isCurrentPath: true,
+      title: '전체 보기',
+    },
+    {
+      href: ROUTE_PATH.FOLLOWING_TWEETS,
+      isCurrentPath: false,
+      title: '팔로잉',
+    },
+  ];
+
   return (
     <Layout isLoggedIn title={<TitleLogo />}>
-      <TweetFeedLayout>{page}</TweetFeedLayout>
+      <TweetFeedLayout navigation={navigationConfig}>{page}</TweetFeedLayout>
     </Layout>
   );
 };

--- a/src/pages/profile/[id]/following.tsx
+++ b/src/pages/profile/[id]/following.tsx
@@ -1,6 +1,7 @@
 import { LoadingSpinner } from '@/components';
 import FollowLayout from '@/components/follows/FollowLayout';
 import FollowingList from '@/components/follows/FollowingList';
+import { ROUTE_PATH } from '@/constants';
 import useFollow from '@/hooks/api/useFollow';
 import { NextPageWithLayout } from '@/pages/_app';
 import { useRouter } from 'next/router';

--- a/src/pages/profile/[id]/tweets.tsx
+++ b/src/pages/profile/[id]/tweets.tsx
@@ -1,0 +1,22 @@
+import { Layout, TitleLogo } from '@/components';
+import TweetsFeed from '@/components/tweets/TweetFeed';
+import TweetFeedLayout from '@/components/tweets/TweetFeedLayout';
+import { END_POINTS } from '@/constants/api';
+import { NextPageWithLayout } from '@/pages/_app';
+import { useRouter } from 'next/router';
+
+const UserTweetFeedPage: NextPageWithLayout = () => {
+  const router = useRouter();
+  const params = new URLSearchParams();
+  params.set('userId', router.query.id as string);
+
+  return <TweetsFeed endpoint={END_POINTS.TWEETS} query={params.toString()} />;
+};
+UserTweetFeedPage.getLayout = function getLayout(page: React.ReactElement) {
+  return (
+    <Layout hasBackButton isLoggedIn title={<TitleLogo />}>
+      <TweetFeedLayout>{page}</TweetFeedLayout>
+    </Layout>
+  );
+};
+export default UserTweetFeedPage;

--- a/src/pages/profile/edit.tsx
+++ b/src/pages/profile/edit.tsx
@@ -13,7 +13,7 @@ const ProfileEdit: NextPageWithLayout = () => {
   } = useEditProfile();
 
   return (
-    <main className="flex flex-col justify-start h-full px-2 mt-2">
+    <main className="flex flex-col justify-start px-2 mt-2 h-fit">
       <div className="flex flex-col items-center gap-2 px-2">
         <div className="relative w-50 h-50">
           {previewImage ? (

--- a/src/pages/tweet/following.tsx
+++ b/src/pages/tweet/following.tsx
@@ -1,6 +1,7 @@
 import { Layout, TitleLogo } from '@/components';
 import TweetsFeed from '@/components/tweets/TweetFeed';
 import TweetFeedLayout from '@/components/tweets/TweetFeedLayout';
+import { ROUTE_PATH } from '@/constants';
 import { END_POINTS } from '@/constants/api';
 
 import { NextPageWithLayout } from '../_app';
@@ -10,9 +11,21 @@ const FollowingTweetFeed: NextPageWithLayout = () => {
 };
 
 FollowingTweetFeed.getLayout = function getLayout(page: React.ReactElement) {
+  const navigationConfig = [
+    {
+      href: ROUTE_PATH.HOME,
+      isCurrentPath: false,
+      title: '전체 보기',
+    },
+    {
+      href: ROUTE_PATH.FOLLOWING_TWEETS,
+      isCurrentPath: true,
+      title: '팔로잉',
+    },
+  ];
   return (
     <Layout isLoggedIn title={<TitleLogo />}>
-      <TweetFeedLayout>{page}</TweetFeedLayout>
+      <TweetFeedLayout navigation={navigationConfig}>{page}</TweetFeedLayout>
     </Layout>
   );
 };

--- a/src/pages/tweet/upload.tsx
+++ b/src/pages/tweet/upload.tsx
@@ -14,9 +14,9 @@ const Upload: NextPageWithLayout = () => {
   } = useUploadTweet();
 
   return (
-    <form className="flex flex-col items-center justify-around h-full px-2" onSubmit={onSubmit}>
+    <form className="flex flex-col items-center justify-around px-2 h-fit" onSubmit={onSubmit}>
       <label
-        className="relative flex items-center justify-center w-full border-2 border-dashed rounded-lg cursor-pointer h-60 border-beige3"
+        className="relative flex items-center justify-center w-full h-56 border-2 border-dashed rounded-lg cursor-pointer border-beige3"
         htmlFor="image"
       >
         <input


### PR DESCRIPTION
# Feature

- 특정 사용자가 작성한 트윗만을 확인하는 트윗피드 생성
- 그에 맞게 연관된 컴포넌트 및 스타일링 수정
- 컨텐츠에 따라 스크롤이 생성되는 트윗피드, 팔로우 리스트에 사용되는 Nested Layout  변경

Closes #65 

# Description

## 프론트엔드
### 트윗 피드에 적용되는 TweetFeed layout 및 Nested Layout 변경
생성하려는 특정 사용자 작성한 트윗피드에서는 Nexted Layout에서 Navigation이 필요하지 않기 때문에 조건부 렌더링을 해야한다.
TweetFeed Layout 내에서 Navagation을 주입하는 것이 아닌, 해당 Navigation이 필요한 페이지에서 주입하는 방식으로 변경한다.

특정 사용자 작성한 트윗피드에서는 해당 Navigation을 렌더하지않고 TweetFeed Layout 의 스타일링과 탑스크롤 버튼기능을 사용한다.

### 전체 트윗 피드를 불러오는 API에서 특정사용자의 트윗피드를 조회하고싶을 경우, 쿼리파람 값(userId)으로 전달
`useInfiniteScrollData`에서 추가하고싶은 쿼리파람을 있을경우 더하는 것으로 구현했다.

```ts
// useInfiniteScrollData.ts
const getKey: GetKey = (index, previousPageData, url, query) => {
  if (index === 0) return `${url}?pageIndex=${index}&limit=${PAGE_SIZE}&${query}`;
  if (!previousPageData || previousPageData.length === 0 || previousPageData.at(-1)?.data.length < PAGE_SIZE) {
    return null;
  }
  return `${url}?pageIndex=${index}&limit=${PAGE_SIZE}&${query}`;
};
```
사용할 때에는 아래와 같다.
```tsx
const UserTweetFeedPage: NextPageWithLayout = () => {
  const router = useRouter();
  const params = new URLSearchParams();
  params.set('userId', router.query.id as string); // 넣어주고 싶은 쿼리

  return <TweetsFeed endpoint={END_POINTS.TWEETS} query={params.toString()} />;
};
UserTweetFeedPage.getLayout = function getLayout(page: React.ReactElement) {
  return (
    <Layout hasBackButton isLoggedIn title={<TitleLogo />}>
      <TweetFeedLayout>{page}</TweetFeedLayout>
    </Layout>
  );
};

```

### 라우팅 변경시,  스크롤 초기화가 필요한 Nested Layout 컴포넌트의 스크롤 값 초기화하는 방법을 변경한다.

#### 변경 전
Nested Layout의 컴포넌트의 네비게이션을 클릭할 경우 스크롤 값을 초기화 했었다.
하지만, 특정 사용자의 트윗 피드가 추가되는 경우에는 Nested Layout에서는 네비게이션 컴포넌트가 렌더되지 말아야 한다.
사용자가 네비게이션 버튼을 누르지않고 다른 버튼을 누를경우에도 Nested Layout 컴포넌트의 스크롤값을 초기화 시켜서, 다른 트윗피드나 팔로잉, 팔로워를 확인 할때마다 계속 최상단의 스크롤에 위치하게 해주는 방식으로 변경이 필요하다.
```ts
    const handleNavigation = async (href: string) => {
      await router.push(href);
      if (containerRef.current) containerRef.current.scrollTop = 0;
    };

```
#### 변경 후
버튼을 통해서 Nested Layout 컴포넌트의 스크롤 값을 초기화 시키는 것이 아닌, 해당 컴포너트가 언마운트 될때마다 최상단으로 초기화를 시킨다.
하지만, **컴포넌트가unmount 될 때와 새로 렌더링 될때 간극이 존재하여 최상단으로 초기화된 상태로 렌더되지 않기 때문에 `useLayoutEffect` 를 사용해서 페인팅 작업 전에 스크롤을 최상단으로 끌어올린다.**
 
```ts
 useLayoutEffect(() => {
      const currentRef = containerRef.current;
      return () => {
        if (currentRef) currentRef.scrollTop = 0;
      };
    }, [router.query]);
```


## 백엔드
기존에 전체 트윗을 호출하는 `/api/tweets` 에서 `req.userId`가 있을 경우에는 특정 사용자(userId)의 전체 트윗을 가져오는 로직을 추가했다.
프리즈마의 `where`을 사용하여 트윗의 작성자가 userId 인 트윗을 전부 가져온다.

```ts
  if (req.method === METHOD.GET && userId) {
    const tweets = await db.tweet.findMany({

// 아래의 코드를 제외하고는 동일
         where: {
        user: {
          id: String(userId),
        },
      },

```

# Additional

