### PR TITLE
Feature #65 페이지 라우팅시 스크롤을 최상단을 초기화 하는 방식을 변경한다. (useLayoutEffect 제거)

### DIFF
--- a/src/components/common/layout/NestedLayout.tsx
+++ b/src/components/common/layout/NestedLayout.tsx
@@ -1,9 +1,7 @@
 import { parameterToString } from '@/libs/client';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { forwardRef, useEffect, useImperativeHandle, useLayoutEffect, useRef } from 'react';
-
-const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+import { forwardRef, useImperativeHandle, useRef } from 'react';
 
 export type Navigation = { href: string; isCurrentPath: boolean; title: string };
 
@@ -25,13 +23,6 @@ const NestedLayout = forwardRef<NestedLayoutHandle, React.PropsWithChildren<{ na
       }),
       []
     );
-
-    useIsomorphicLayoutEffect(() => {
-      const currentRef = containerRef.current;
-      return () => {
-        if (currentRef) currentRef.scrollTop = 0;
-      };
-    }, [router.query]);
 
     return (
       <>
@@ -55,6 +46,7 @@ const NestedLayout = forwardRef<NestedLayoutHandle, React.PropsWithChildren<{ na
             'h-[calc(100vh-8rem)] px-2 overflow-y-auto overflow-x-hidden',
             navigation?.length ? '  pt-10' : ''
           )}
+          key={router.pathname}
           ref={containerRef}
         >
           {children}

--- a/src/hooks/api/useInfiniteScrollData.ts
+++ b/src/hooks/api/useInfiniteScrollData.ts
@@ -13,7 +13,11 @@ type GetKey = (
 
 const getKey: GetKey = (index, previousPageData, url, query) => {
   if (index === 0) return `${url}?pageIndex=${index}&limit=${PAGE_SIZE}&${query}`;
-  if (!previousPageData || previousPageData.length === 0 || previousPageData.at(-1)?.data.length < PAGE_SIZE) {
+  if (
+    !previousPageData ||
+    previousPageData.length === 0 ||
+    previousPageData[previousPageData.length - 1]?.data.length < PAGE_SIZE
+  ) {
     return null;
   }
   return `${url}?pageIndex=${index}&limit=${PAGE_SIZE}&${query}`;


### PR DESCRIPTION
# Feature
페이지 라우티시 스크롤을 최상단을 초기화 하는 방식을 변경한다.
(기능은 동일하되, 초기화 방식은 변경)

Closes #65 
Closes #66 

# Description

### useLayoutEffect 제거 후, pathname 을 key으로 설정

|변경 전|변경 후|
|-|-|
|useLayoutEffect 를 사용하여 페인팅 이전에 스크롤을 최상단으로 올리는 방식|pathname 에 따라 고유한 키값을 주는 방식|

그렇게 되면 라우팅할 때마다 (pathname) 이 변경될 때, 리액트는 새로운 컴포넌트로 인식하고 새로이 그려지기 때문에 스크롤 값이 초기화 된다.

리액트 바깥에서 제어하는 useLayoutEffect를 쓰는 것보다, key 값을 사용하여 리액트 라이프 사이클 내부에서 관리한다.

# Additional
만약, 리스트페이지에서 하나의 트윗을 선택하여 상세페이지를 확인하 후, 뒤로가기를 했을 경우에는 스크롤이 저장되지않아서 사용감이 떨어질 수 있다.
이부분에 대해서는 더 연구가 필요해보인다.