### PR TITLE
refactor: 이미지 등록 및 api 호출 최적화를 위하여 abort signal 적용

### DIFF
--- a/src/hooks/common/useSelectImage.ts
+++ b/src/hooks/common/useSelectImage.ts
@@ -1,20 +1,26 @@
 import getImageId from '@/libs/client/getImageId';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 export default function useSelectImage() {
   const [isImageLoading, setIsImageLoading] = useState(false);
   const [imageId, setImageId] = useState('');
   const [previewImage, setPreviewImage] = useState('');
+  const uploadControllerRef = useRef<AbortController | null>(null);
 
   const selectedImage = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (uploadControllerRef.current) {
+      uploadControllerRef.current.abort();
+    }
     if (event.target.files && event.target.files.length > 0) {
+      uploadControllerRef.current = new AbortController();
+
       setIsImageLoading(true);
 
       const file = event.target.files[0];
       const previewImageUrl = URL.createObjectURL(file);
       setPreviewImage(previewImageUrl);
 
-      const id = await getImageId(file, file.name);
+      const id = await getImageId(file, file.name, uploadControllerRef.current);
       setImageId(id);
 
       setIsImageLoading(false);
@@ -26,6 +32,10 @@ export default function useSelectImage() {
     URL.revokeObjectURL(previewImage);
     setImageId('');
     setPreviewImage('');
+    if (uploadControllerRef.current) {
+      uploadControllerRef.current.abort();
+      uploadControllerRef.current = null;
+    }
   };
 
   return { cancelImage, imageId, isImageLoading, previewImage, selectedImage };

--- a/src/libs/client/getImageId.ts
+++ b/src/libs/client/getImageId.ts
@@ -1,12 +1,41 @@
-export default async function getImageId(imageFile: File, fileName: string) {
-  const {
-    data: { uploadURL },
-  } = await (await fetch('/api/files')).json();
-  const form = new FormData();
-  form.append('file', imageFile, fileName);
-  const {
-    result: { id },
-  } = await (await fetch(uploadURL, { body: form, method: 'POST' })).json();
+import { METHOD } from '@/constants';
+import { END_POINTS } from '@/constants/api';
 
-  return id;
+export default async function getImageId(imageFile: File, fileName: string, controller: AbortController) {
+  const signal = controller.signal;
+
+  try {
+    const uploadUrlResponse = await fetch(END_POINTS.FILES, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      method: METHOD.GET,
+      signal,
+    });
+    if (!uploadUrlResponse.ok) throw new Error('이미지 등록에 실패하였습니다.');
+    const {
+      data: { uploadURL },
+    } = await uploadUrlResponse.json();
+
+    const form = new FormData();
+    form.append('file', imageFile, fileName);
+
+    const uploadResponse = await fetch(uploadURL, {
+      body: form,
+      method: METHOD.POST,
+      signal,
+    });
+    if (!uploadResponse.ok) throw new Error('이미지 등록에 실패하였습니다.');
+    const {
+      result: { id },
+    } = await uploadResponse.json();
+
+    return id;
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      console.log('Abort Signal');
+    } else {
+      console.error('잠시후 요청 부탁드립니다.:', error);
+    }
+  }
 }


### PR DESCRIPTION
# Feature

이미지 등록 및 api 호출 최적화를 위하여 abort signal 적용

Closes #73 

# Description

## image cloudflare에 등록시 abort signal을 적용한다.

### 변경 이유

사용자 경험을 위해 사용자가 추가하거나 수정할 이미지를 선택할때, cloudflare에 image에 바로 등록을 진행하여 등록에 지연을 방지하고 있다.
하지만, 사용자가 이미지를 선택하기 위해 여러 이미지를 연속적으로 변경하게 된다면 이전에 선택한 사용하지않는 이미지도 함께 저장되는 리소스 낭비가 일어난다.
이를 막기위해 cloudflare에 등록하는 api 호출에 abort signal을 추가한다. 사용자가 연속적으로 이미지를 바꾸거나 이미지 등록을 취소할때 이미 호출된 cloudfalre 이미지 등록 요청을 취소한다.

### 변경 사항

|변경 전 | 변경 후|
|-|-|
|사용자가 이미지 등록시 프리뷰를 보여주고 Image cloudeflare 등록. 사용자가 계속적으로 이미지를 바꾸게 된다면 모든 이미지가 저장된다는 문제점이 존재| 사용자가 연속적으로 이미지를 변경할 경우, 등록전에 이미지를 수정한다면 이전 요청은 취소하고 마지막 요청만 진행한다.|

# Additional

- https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
- debounce 기능이 적용되어있는 곳에 abort signal을 적용하는 것을 계획할 것